### PR TITLE
Fix package name (it's obviously for python).

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ git clone git@github.com:sendgrid/sendgrid-python.git
 Using Pypi:
 
 ```
-easy_install sendgrid-python
+easy_install sendgrid
 ```
 
 ## SendGrid APIs ##

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,14 @@
-import os
 from setuptools import setup, find_packages
 
 
 setup(
-    name='sendgrid-python',
+    name='sendgrid',
     version='0.1.0',
     author='Kane Kim',
     author_email='kane@sendgrid.com',
     packages=find_packages(),
     url='https://github.com/sendgrid/sendgrid-python/',
     license='LICENSE.txt',
-    description='Sendgrid library for python',
-    long_description='Sendgrid library for python',
+    description='SendGrid client',
+    long_description='SendGrid client',
 )


### PR DESCRIPTION
The repo name is fine since you have a lot of clients, but I should have to remember if it's `pip install sendgrid-python`, `pip install python-sendgrid`, or `pip install pysendgrid`

If you push this back to pypi then people can just do `pip install sendgrid` (or `easy_install sendgrid`)
