### PR TITLE
Allow text or html to be set to None.

### DIFF
--- a/sendgrid/message.py
+++ b/sendgrid/message.py
@@ -23,7 +23,7 @@ class Message(object):
         Raises:
             ValueError: on invalid arguments
         """
-        if not (text + html):
+        if not text and not html:
             raise ValueError("Either html or text should be provided")
 
         self.from_name = ''

--- a/test/test_message.py
+++ b/test/test_message.py
@@ -23,6 +23,12 @@ class TestMessage(unittest.TestCase):
         # pass text only
         sendgrid.Message(("example1@example.com", "John, Doe"), "subject1", text="text")
 
+        # pass None for html
+        sendgrid.Message(("example1@example.com", "John, Doe"), "subject1", text="text", html=None)
+
+        # pass None for text
+        sendgrid.Message(("example1@example.com", "John, Doe"), "subject1", html="html", text=None)
+
 
     def test_recipients_adding(self):
         message = sendgrid.Message("example@example.com", "subject1", "plain_text", "html")


### PR DESCRIPTION
The odd use of string concatenation in the Message constructor is the only thing keeping it from accepting None for text or html.
