### PR TITLE
Add Content-ID header if cid is specified.

### DIFF
--- a/sendgrid/transport/smtp.py
+++ b/sendgrid/transport/smtp.py
@@ -182,7 +182,7 @@ class Smtp(object):
 
         msg.add_header('Content-Disposition', 'attachment', filename=filename)
         
-        if attach['cid']:
+        if attach.get('cid', False):
           msg.add_header('Content-ID', '<%s>' % attach['cid'])
 
         return msg

--- a/test/test_smtp_transport.py
+++ b/test/test_smtp_transport.py
@@ -46,6 +46,9 @@ class TestTransports(unittest.TestCase):
     def test_smtp_transport_content_id_header(self):
         smtp_transport = smtp.Smtp('username', 'password', tls=False)
 
+        f = smtp_transport._getFileMIME({'file': 'img.png', 'name': 'contents'})
+        self.assertEqual(None, f.get('Content-ID'))
+
         f = smtp_transport._getFileMIME({'file': 'img.png', 'name': 'contents', 'cid': None})
         self.assertEqual(None, f.get('Content-ID'))
 


### PR DESCRIPTION
Message.add_attachment takes an optional cid keyword argument. However,
  if it is given, it's not used to actually set a Content-ID header.
