### PR TITLE
Don't include a Content-Disposition header when cid is provided

### DIFF
--- a/sendgrid/transport/smtp.py
+++ b/sendgrid/transport/smtp.py
@@ -180,9 +180,9 @@ class Smtp(object):
             msg.set_payload(data)
             encoders.encode_base64(msg)
 
-        msg.add_header('Content-Disposition', 'attachment', filename=filename)
-        
         if attach.get('cid', False):
-          msg.add_header('Content-ID', '<%s>' % attach['cid'])
+            msg.add_header('Content-ID', '<%s>' % attach['cid'])
+        else:
+            msg.add_header('Content-Disposition', 'attachment', filename=filename)
 
         return msg

--- a/test/test_smtp_transport.py
+++ b/test/test_smtp_transport.py
@@ -48,12 +48,15 @@ class TestTransports(unittest.TestCase):
 
         f = smtp_transport._getFileMIME({'file': 'img.png', 'name': 'contents'})
         self.assertEqual(None, f.get('Content-ID'))
+        self.assertEqual('attachment; filename="contents"', f.get('Content-Disposition'))
 
         f = smtp_transport._getFileMIME({'file': 'img.png', 'name': 'contents', 'cid': None})
         self.assertEqual(None, f.get('Content-ID'))
+        self.assertEqual('attachment; filename="contents"', f.get('Content-Disposition'))
 
         f = smtp_transport._getFileMIME({'file': 'img.png', 'name': 'contents', 'cid': 'cid'})
         self.assertEqual('<cid>', f.get('Content-ID'))
+        self.assertEqual(None, f.get('Content-Disposition'))
 
 
 class FakeException(IOError):


### PR DESCRIPTION
Providing both a Content-ID header and Content-Disposition header
with type 'attachment' confused some email clients. If no
Content-Disposition header is given, it defaults to 'inline'
which is what is desired when using cids.
