### PR TITLE
Preventing SMTP login with empty credentials

### DIFF
--- a/sendgrid/transport/smtp.py
+++ b/sendgrid/transport/smtp.py
@@ -117,7 +117,10 @@ class Smtp(object):
             server.starttls()
 
         try:
-            server.login(self.username, self.password)
+            # Don't try to authenticate the user if we don't have his/her
+            # credentials or if they're empty.
+            if self.username and self.password:
+                server.login(self.username, self.password)
             server.sendmail(email_message['From'],
                             recipients,
                             email_message.as_string())


### PR DESCRIPTION
We use sendgrid at Yipit but our functional tests
are performed against dummy python servers that don't
implement the auth layer.

So it would help a lot if we could just skip the auth
step for that reason.
