### PR TITLE
Fix error on attaching files in the message

### DIFF
--- a/sendgrid/transport/web.py
+++ b/sendgrid/transport/web.py
@@ -69,7 +69,7 @@ class Http(object):
                     f = open(attach['file'], 'rb')
                     data['files[' + attach['name'] + ']'] = f.read()
                     f.close()
-                except IOError:
+                except:
                     data['files[' + attach['name'] + ']'] = attach['file']
 
         optional_params = {


### PR DESCRIPTION
When attach['file'] contains the actual data content of a file, IOError isn't the only possible exception for open(attach['file'], 'rb')

Another possible exception is 

```
TypeError: file() argument 1 must be encoded string without NULL bytes, not str
```

When there's '\0' in the data content. But there could be other exceptions happen as well.

In transport/smtp.py, Smtp:_getFileMIME method, you use 'try...except' to catch all exceptions, I think at least it's better than just catching IOError. So I suggest you do the same in web.py.
