### PR TITLE
use pip over easy_install

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ git clone git@github.com:sendgrid/sendgrid-python.git
 Using PyPI:
 
 ```
+pip install sendgrid
+```
+Or
+```
 easy_install sendgrid
 ```
 


### PR DESCRIPTION
pip is recommended way to install packages in Python community. I have added pip as install option, along with easy_install
