### PR TITLE
Fixed UTF-8 encoding crash in web module

### DIFF
--- a/sendgrid/transport/web.py
+++ b/sendgrid/transport/web.py
@@ -85,7 +85,11 @@ class Http(object):
 
         for key in optional_params:
             if optional_params[key]:
-                data[key] = optional_params[key]
+                val = optional_params[key]
+                if isinstance(val, unicode):
+                    data[key] = val.encode('utf-8')
+                elif isinstance(val, str):
+                    data[key] = val.decode('utf-8')
 
         data = urllib.urlencode(data, 1)
         req = urllib2.Request(url, data)


### PR DESCRIPTION
This commit addressed the issue in the SMTP module:
https://github.com/sendgrid/sendgrid-python/commit/66a34c7c50033c7fdb704efad7d23fd5cd20c4e3

So here's one to address it in the Web module.
