### PR TITLE
Refactor

### DIFF
--- a/sendgrid/message.py
+++ b/sendgrid/message.py
@@ -73,7 +73,8 @@ class Mail(SMTPAPIHeader):
     self.html = html
 
   def add_bcc(self, bcc):
-    self.bcc.append(bcc)
+    name, email = rfc822.parseaddr(bcc.replace(',', ''))
+    self.bcc.append(email)
 
   def set_replyto(self, replyto):
     self.reply_to = replyto


### PR DESCRIPTION
This begins a large refactor of the python sendgrid library - to bring it more inline with python good practices and to also deprecate SMTP from the library in favor of the web api (2-3 times faster).
