### PR TITLE
updated to v0.2.5 to use urllib instead of external requests library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-requests==2.2.1
 smtpapi==0.1.1

--- a/sendgrid/message.py
+++ b/sendgrid/message.py
@@ -1,95 +1,95 @@
 import io
 try:
-  import rfc822
+    import rfc822
 except Exception as e:
-  import email.utils as rfc822
+    import email.utils as rfc822
 from smtpapi import SMTPAPIHeader
 
+
 class Mail(SMTPAPIHeader):
-  """
-  Sendgrid Message
-  """
-
-  def __init__(self, **opts):
     """
-    Constructs Sendgrid Message object
-
-    Args:
-      to: Receipient
-      to_name: Receipient name
-      from: Sender
-      subject: Email title
-      text: Email body
-      html: Email body
-      bcc: Receipient
-      reply_to: Reply address
-      date: Set date
-      headers: Set headers
-      x-smtpapi: Set SG custom header
-      files: Attachments
-
+    SendGrid Message
     """
-    super(Mail, self).__init__()
-    self.to = opts.get('to', [])
-    self.to_name = opts.get('to_name', [])
-    self.from_email = opts.get('from_email', '')
-    self.from_name = opts.get('from_name', '')
-    self.subject = opts.get('subject', '')
-    self.text = opts.get('text', '')
-    self.html = opts.get('html', '')
-    self.bcc = opts.get('bcc', [])
-    self.reply_to = opts.get('reply_to', '')
-    self.files = opts.get('files', {})
-    self.headers = opts.get('headers', '')
-    self.date = opts.get('date', rfc822.formatdate())
 
-  def add_to(self, to):
-    name, email = rfc822.parseaddr(to.replace(',', ''))
-    if email:
-      self.to.append(email)
-    if name:
-      self.add_to_name(name);
+    def __init__(self, **opts):
+        """
+        Constructs SendGrid Message object
 
-  def add_to_name(self, to_name):
-    self.to_name.append(to_name)
+        Args:
+            to: Recipient
+            to_name: Recipient name
+            from: Sender
+            subject: Email title
+            text: Email body
+            html: Email body
+            bcc: Recipient
+            reply_to: Reply address
+            date: Set date
+            headers: Set headers
+            x-smtpapi: Set SG custom header
+            files: Attachments
+        """
+        super(Mail, self).__init__()
+        self.to = opts.get('to', [])
+        self.to_name = opts.get('to_name', [])
+        self.from_email = opts.get('from_email', '')
+        self.from_name = opts.get('from_name', '')
+        self.subject = opts.get('subject', '')
+        self.text = opts.get('text', '')
+        self.html = opts.get('html', '')
+        self.bcc = opts.get('bcc', [])
+        self.reply_to = opts.get('reply_to', '')
+        self.files = opts.get('files', {})
+        self.headers = opts.get('headers', '')
+        self.date = opts.get('date', rfc822.formatdate())
 
-  def set_from(self, from_email):
-    name, email = rfc822.parseaddr(from_email.replace(',', ''))
-    if email:
-      self.from_email = email
-    if name:
-      self.set_from_name(name)
+    def add_to(self, to):
+        name, email = rfc822.parseaddr(to.replace(',', ''))
+        if email:
+            self.to.append(email)
+        if name:
+            self.add_to_name(name)
 
-  def set_from_name(self, from_name):
-    self.from_name = from_name
+    def add_to_name(self, to_name):
+        self.to_name.append(to_name)
 
-  def set_subject(self, subject):
-    self.subject = subject
+    def set_from(self, from_email):
+        name, email = rfc822.parseaddr(from_email.replace(',', ''))
+        if email:
+            self.from_email = email
+        if name:
+            self.set_from_name(name)
 
-  def set_text(self, text):
-    self.text = text
+    def set_from_name(self, from_name):
+        self.from_name = from_name
 
-  def set_html(self, html):
-    self.html = html
+    def set_subject(self, subject):
+        self.subject = subject
 
-  def add_bcc(self, bcc):
-    name, email = rfc822.parseaddr(bcc.replace(',', ''))
-    self.bcc.append(email)
+    def set_text(self, text):
+        self.text = text
 
-  def set_replyto(self, replyto):
-    self.reply_to = replyto
+    def set_html(self, html):
+        self.html = html
 
-  def add_attachment(self, name, filepath):
-    self.files[name] = open(filepath, "r").read()
+    def add_bcc(self, bcc):
+        name, email = rfc822.parseaddr(bcc.replace(',', ''))
+        self.bcc.append(email)
 
-  def add_attachment_stream(self, name, string):
-    if isinstance(string, str):
-      self.files[name] = string
-    elif isinstance(string, io.BytesIO):
-      self.files[name] = string.read()
+    def set_replyto(self, replyto):
+        self.reply_to = replyto
 
-  def set_headers(self, headers):
-    self.headers = headers
+    def add_attachment(self, name, filepath):
+        self.files[name] = open(filepath, "r").read()
 
-  def set_date(self, date):
-    self.date = date
+    def add_attachment_stream(self, name, string):
+        if isinstance(string, str):
+            self.files[name] = string
+        elif isinstance(string, io.BytesIO):
+            self.files[name] = string.read()
+
+    def set_headers(self, headers):
+        self.headers = headers
+
+    def set_date(self, date):
+        self.date = date

--- a/sendgrid/sendgrid.py
+++ b/sendgrid/sendgrid.py
@@ -1,44 +1,80 @@
-import requests
+import sys
+if sys.hexversion < 0x03000000:
+    # python 2
+    import urllib
+    import urllib2
+else:
+    # python 3
+    import urllib.parse
+    import urllib.request
+
 
 class SendGridClient(object):
-  """
-  SendGrid API
-  """
-  def __init__(self, username, password, **opts):
     """
-    Construct Sendgrid API object
-    Args:
-        username: Sendgrid username
-        password: Sendgrid password
-        user: Send mail on behalf of this user (web only)
+    SendGrid API
     """
-    self.username = username
-    self.password = password
-    self.mailUrl = 'https://api.sendgrid.com/api/mail.send.json'
-    self.proxies = opts.get('proxies', None)
+    def __init__(self, username, password, **opts):
+        """
+        Construct SendGrid API object
+        Args:
+            username: SendGrid username
+            password: SendGrid password
+            user: Send mail on behalf of this user (web only)
+        """
+        self.username = username
+        self.password = password
+        self.mail_url = 'https://api.sendgrid.com/api/mail.send.json'
 
-  def _build_body(self, message):
-    values = {}
-    values['api_user'] = self.username
-    values['api_key'] = self.password
-    values['to[]'] = message.to
-    values['toname[]'] = message.to_name
-    values['from'] = message.from_email
-    values['fromname'] = message.from_name
-    values['subject'] = message.subject
-    values['text'] = message.text
-    values['html'] = message.html
-    values['replyto'] = message.reply_to
-    values['headers'] = message.headers
-    values['date'] = message.date
-    for filename in message.files:
-      values['files[' + filename + ']'] = message.files[filename]
-    values['x-smtpapi'] = message.json_string()
-    return values
+        # urllib cannot connect to SSL servers using proxies
+        self.proxies = opts.get('proxies', None)
 
-  def send(self, message):
-    try:
-      r = requests.post(url=self.mailUrl, data=self._build_body(message), proxies=self.proxies)
-      return r.status_code, r.json()
-    except requests.exceptions.ConnectionError as e:
-      raise e
+    def _build_body(self, message):
+        values = {
+            'api_user': self.username,
+            'api_key': self.password,
+            'to[]': message.to,
+            'toname[]': message.to_name,
+            'from': message.from_email,
+            'fromname': message.from_name,
+            'subject': message.subject,
+            'text': message.text,
+            'html': message.html,
+            'replyto': message.reply_to,
+            'headers': message.headers,
+            'date': message.date,
+            'x-smtpapi': message.json_string()
+        }
+        for filename in message.files:
+            values['files[' + filename + ']'] = message.files[filename]
+        return values
+
+    def send(self, message):
+        if sys.hexversion < 0x03000000:
+            # python 2
+            try:
+                if self.proxies:
+                    proxy_support = urllib2.ProxyHandler(self.proxies)
+                    opener = urllib2.build_opener(proxy_support)
+                    urllib2.install_opener(opener)
+                data = urllib.urlencode(self._build_body(message)).encode('utf-8')
+                req = urllib2.Request(self.mail_url, data)
+                response = urllib2.urlopen(req)
+                body = response.read()
+                return response.getcode(), body
+            except urllib2.URLError as e:
+                raise e
+
+        else:
+            # python 3
+            try:
+                if self.proxies:
+                    proxy_support = urllib.request.ProxyHandler(self.proxies)
+                    opener = urllib.request.build_opener(proxy_support)
+                    urllib.request.install_opener(opener)
+                data = urllib.parse.urlencode(self._build_body(message)).encode('utf-8')
+                req = urllib.request.Request(self.mail_url, data)
+                response = urllib.request.urlopen(req)
+                body = response.read()
+                return response.getcode(), body
+            except urllib.error.URLError as e:
+                raise e

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='sendgrid',
-    version='0.2.4',
+    version='0.2.5',
     author='Yamil Asusta',
     author_email='yamil@sendgrid.com',
     url='https://github.com/sendgrid/sendgrid-python/',
@@ -11,7 +11,6 @@ setup(
     description='SendGrid library for Python',
     long_description=open('./README.rst').read(),
     install_requires=[
-        'requests',
         'smtpapi'
     ],
 )

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -3,45 +3,67 @@ import unittest
 import json
 from sendgrid import SendGridClient, Mail
 
+
 class TestSendGrid(unittest.TestCase):
 
-  def setUp(self):
-    self.sg = SendGridClient(os.getenv('SG_USER'), os.getenv('SG_PWD'))
+    def setUp(self):
+        self.sg = SendGridClient(os.getenv('SG_USER'), os.getenv('SG_PWD'))
 
-  def test_send(self):
-    m = Mail()
-    m.add_to('John, Doe <john@email.com>')
-    m.set_subject('test')
-    m.set_html('WIN')
-    m.set_text('WIN')
-    m.set_from('doe@email.com')
-    m.add_substitution('subKey', 'subValue')
-    m.add_section('testSection', 'sectionValue')
-    m.add_category('testCategory')
-    m.add_unique_arg('testUnique', 'uniqueValue')
-    m.add_filter('testFilter', 'filter', 'filterValue')
-    m.add_attachment_stream('testFile', 'fileValue')
-    self.sg.send(m)
-    url = self.sg._build_body(m)
-    url.pop('api_key', None)
-    url.pop('api_user', None)
-    url.pop('date', None)
-    testUrl = json.loads('''{"to[]": ["john@email.com"],
-    "toname[]": ["John Doe"],
-    "html": "WIN",
-    "text": "WIN",
-    "subject": "test",
-    "files[testFile]": "fileValue",
-    "from": "doe@email.com",
-    "headers": "",
-    "fromname": "",
-    "replyto": ""}''')
-    testUrl['x-smtpapi'] = json.dumps(json.loads('''{"sub":{"subKey":["subValue"]},
-      "section":{"testSection":"sectionValue"},
-      "category":["testCategory"],
-      "unique_args":{"testUnique":"uniqueValue"},
-      "filters":{"testFilter":{"settings":{"filter":"filterValue"}}}}'''))
-    self.assertEqual(url, testUrl)
+    def test_send(self):
+        m = Mail()
+        m.add_to('John, Doe <john@email.com>')
+        m.set_subject('test')
+        m.set_html('WIN')
+        m.set_text('WIN')
+        m.set_from('doe@email.com')
+        m.add_substitution('subKey', 'subValue')
+        m.add_section('testSection', 'sectionValue')
+        m.add_category('testCategory')
+        m.add_unique_arg('testUnique', 'uniqueValue')
+        m.add_filter('testFilter', 'filter', 'filterValue')
+        m.add_attachment_stream('testFile', 'fileValue')
+        self.sg.send(m)
+
+        url = self.sg._build_body(m)
+        url.pop('api_key', None)
+        url.pop('api_user', None)
+        url.pop('date', None)
+        test_url = json.loads('''
+            {
+                "to[]": ["john@email.com"],
+                "toname[]": ["John Doe"],
+                "html": "WIN",
+                "text": "WIN",
+                "subject": "test",
+                "files[testFile]": "fileValue",
+                "from": "doe@email.com",
+                "headers": "",
+                "fromname": "",
+                "replyto": ""
+            }
+            ''')
+        test_url['x-smtpapi'] = json.dumps(json.loads('''
+            {
+                "sub": {
+                    "subKey": ["subValue"]
+                },
+                "section": {
+                    "testSection":"sectionValue"
+                },
+                "category": ["testCategory"],
+                "unique_args": {
+                    "testUnique":"uniqueValue"
+                },
+                "filters": {
+                    "testFilter": {
+                        "settings": {
+                            "filter": "filterValue"
+                        }
+                    }
+                }
+            }
+            '''))
+        self.assertEqual(url, test_url)
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()


### PR DESCRIPTION
1. The external package 'requests' was causing 'too many redirect' errors on app engine, reported by a few users
2. PEP8 all the things!
3. updated to v0.2.5

Tested manually with python 3.3.2 and 2.7.6
