### PR TITLE
Minor fix for adding attachments

### DIFF
--- a/sendgrid/message.py
+++ b/sendgrid/message.py
@@ -106,12 +106,12 @@ class Mail(SMTPAPIHeader):
     def set_replyto(self, replyto):
         self.reply_to = replyto
 
-    def add_attachment(self, name, file):
-        if isinstance(file, str): #filepath
-            with open(file, 'rb') as f:
+    def add_attachment(self, name, file_):
+        if isinstance(file_, str): #filepath
+            with open(file_, 'rb') as f:
                 self.files[name] = f.read()
-        elif hasattr(file, 'read'):
-            self.files[name] = f.read()
+        elif hasattr(file_, 'read'):
+            self.files[name] = file_.read()
 
     def add_attachment_stream(self, name, string):
         if isinstance(string, str):


### PR DESCRIPTION
There was a [minor error on a previous commit](https://github.com/sendgrid/sendgrid-python/blob/3d3ec5a6b2b9d6ee34048b828ef9d29f1ac23e5c/sendgrid/message.py#L114), where `f` should have  actually been `file`. I've gone ahead and fixed the error, and also appended an underscore to the `file` variable name (since `file` is a built-in Python function, and can be slightly confusing).
