### PR TITLE
Fix processing of multiple 'to_name' unicode objects.

### DIFF
--- a/sendgrid/message.py
+++ b/sendgrid/message.py
@@ -72,7 +72,8 @@ class Mail(SMTPAPIHeader):
         elif sys.version_info < (3, 0) and isinstance(to_name, unicode):
             self.to_name.append(to_name.encode('utf-8'))
         elif hasattr(to_name, '__iter__'):
-            self.to_name = self.to_name + to_name
+            for tn in to_name:
+                self.add_to_name(tn)
 
     def add_cc(self, cc):
         if isinstance(cc, str):


### PR DESCRIPTION
Currently, the method sendgrid.message.Mail.add_to_name only encodes singular
unicode object 'to_name' names to Python str objects. Lists of multiple unicode
objects passed into the aforementioned method does not elicit the same encoding
process. This commit fixes that.
