### PR TITLE
Remove unittest2 in Python 2.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,9 +8,9 @@ with open('sendgrid/version.py') as f:
 
 def getRequires():
     deps = ['smtpapi==0.1.3']
-    if sys.version_info < (3, 0):
+    if sys.version_info < (2, 7):
         deps.append('unittest2')
-    else:
+    elif (3, 0) <= sys.version_info:
         deps.append('unittest2py3k')
     return deps
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def getRequires():
     deps = ['smtpapi==0.1.3']
     if sys.version_info < (2, 7):
         deps.append('unittest2')
-    elif (3, 0) <= sys.version_info:
+    elif (3, 0) <= sys.version_info < (3, 2):
         deps.append('unittest2py3k')
     return deps
 

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,8 @@
 import os
-import unittest2 as unittest
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import json
 import sys
 try:


### PR DESCRIPTION
There's no reason to use unittest2 in Python 2.7:

* Everything that unittest2 adds is already present in Python 2.7.
* Older versions of unittest2 has a nasty bug whereby its base class does not call super(); this
  can result in some mix-in class's setUp()s not being called at all.
* It's no longer maintained.