### PR TITLE
Use persistent HTTP requests by default.

### DIFF
--- a/sendgrid/sendgrid.py
+++ b/sendgrid/sendgrid.py
@@ -145,7 +145,9 @@ class SendGridClient(object):
             try:
                 return self._make_persistent_request(message)
             except timeout:
-                pass  # ignore timeout for persistent requests
+                # Timeout on persistent request, falling back to
+                # non-persistent request
+                pass
         return self._make_nonpersistent_request(message)
 
     def send(self, message):

--- a/sendgrid/sendgrid.py
+++ b/sendgrid/sendgrid.py
@@ -1,12 +1,13 @@
-import httplib
 import sys
 from socket import timeout
 from .version import __version__
 try:
+    import http.client as http_client
     import urllib.request as urllib_request
     from urllib.parse import urlencode
     from urllib.error import HTTPError
 except ImportError:  # Python 2
+    import httplib as http_client
     import urllib2 as urllib_request
     from urllib2 import HTTPError
     from urllib import urlencode
@@ -126,13 +127,14 @@ class SendGridClient(object):
             headers['Authorization'] = 'Bearer ' + self.password
         for _ in range(self._max_retry):
             if self._server is None:
-                self._server = httplib.HTTPSConnection(domain, int(self.port))
+                self._server = http_client.HTTPSConnection(domain,
+                                                           int(self.port))
             self._server.request('POST', self.endpoint, data, headers=headers)
             try:
                 response = self._server.getresponse()
                 body = response.read()
                 return response.status, body
-            except httplib.BadStatusLine:
+            except http_client.BadStatusLine:
                 # Persistent request timeout reached. Retrying...
                 self._server.close()
                 self._server = None


### PR DESCRIPTION
Using persistent HTTP requests (Connection: Keep-Alive) allows to send messages four to five times faster.

Benchmark result with 10 000 mails sent with a persistent connections (Connection: Keep-Alive), and 10 000 other mails sent with "normal" connections:

$ python test_benchmark_10k_mails.py
persistent         . . . . . . . . . .
nonpersistent   . . . . . . . . . .
duration_persistent           = 242.951007 sec
duration_nonpersistent     = 1227.724485 sec
messages sent 5.053383 times faster with persistence

Benchmark code here: http://pastebin.com/5mSu452V
