### PR TITLE
Fix Python3 support

### DIFF
--- a/sendgrid/message.py
+++ b/sendgrid/message.py
@@ -165,7 +165,7 @@ class Mail(object):
             self.headers = json.loads(self.headers)
         if isinstance(headers, str):
             headers = json.loads(headers)
-        for key, value in headers.iteritems():
+        for key, value in headers.items():
             self.headers[key] = value
 
     def set_date(self, date):


### PR DESCRIPTION
`iteritems` was removed in Python3. This change replaces `iteritems` with `items`. It does impact Python2 semantics a little (it creates a temporary list), but since the number of headers in a email is small, it should not impact performance and definitely not functionality.

This fixes #126 .