### PR TITLE
Include MIT.LICENSE in release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.rst
+include MIT.LICENSE
 recursive-exclude test *


### PR DESCRIPTION
MIT License is template based and should be distributed together within the source tarball.