### PR TITLE
change timeout to opts variable

### DIFF
--- a/sendgrid/sendgrid.py
+++ b/sendgrid/sendgrid.py
@@ -110,7 +110,7 @@ class SendGridClient(object):
             # Using API key
             req.add_header('Authorization', 'Bearer ' + self.password)
 
-        response = urllib_request.urlopen(req, self.timeout)
+        response = urllib_request.urlopen(req, timeout = self.timeout)
         body = response.read()
         return response.getcode(), body
 

--- a/sendgrid/sendgrid.py
+++ b/sendgrid/sendgrid.py
@@ -51,6 +51,7 @@ class SendGridClient(object):
         self.endpoint = opts.get('endpoint', '/api/mail.send.json')
         self.mail_url = self.host + ':' + self.port + self.endpoint
         self._raise_errors = opts.get('raise_errors', False)
+        self.timeout = opts.get('timeout', 10)
         # urllib cannot connect to SSL servers using proxies
         self.proxies = opts.get('proxies', None)
 
@@ -109,7 +110,7 @@ class SendGridClient(object):
             # Using API key
             req.add_header('Authorization', 'Bearer ' + self.password)
 
-        response = urllib_request.urlopen(req, timeout=10)
+        response = urllib_request.urlopen(req, self.timeout)
         body = response.read()
         return response.getcode(), body
 


### PR DESCRIPTION
Instead of having the timeout hardcoded in _make_request I changed it to be part of the opts that can be passed when creating a SendGridClient object. 

For example:

```sg = sendgrid.SendGridClient(MY_SENDGRID_KEY, **{'timeout': 45})```