### PR TITLE
Update smtpapi to 0.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open('sendgrid/version.py') as f:
 
 
 def getRequires():
-    deps = ['smtpapi==0.2.0']
+    deps = ['smtpapi==0.3.1']
     if sys.version_info < (2, 7):
         deps.append('unittest2')
     elif (3, 0) <= sys.version_info < (3, 2):


### PR DESCRIPTION
This updates the Python [smtpapi](https://github.com/sendgrid/smtpapi-python) library to 0.3.1, the latest version that has been released.

This closes https://github.com/sendgrid/sendgrid-python/issues/160.