### PR TITLE
update python-http-client to 1.2.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ if os.path.exists('README.txt'):
     long_description = open('README.txt').read()
 
 def getRequires():
-    deps = ['smtpapi==0.3.1', 'python_http_client==1.2.3']
+    deps = ['smtpapi==0.3.1', 'python_http_client==1.2.4']
     if sys.version_info < (2, 7):
         deps.append('unittest2')
     elif (3, 0) <= sys.version_info < (3, 2):


### PR DESCRIPTION
Doesn't look like there were any code changes between 1.2.3 and 1.2.4, but this will silence a few 'outdated' warnings.