### PR TITLE
Refactored attachments(...) in sendgrid/helpers/inbound/parse.py, doc…

### DIFF
--- a/sendgrid/helpers/inbound/parse.py
+++ b/sendgrid/helpers/inbound/parse.py
@@ -13,63 +13,68 @@ class Parse(object):
         self._payload = request.form
         self._raw_payload = request.data
 
-    """Return a dictionary of key/values in the payload received from
-       the webhook"""
     def key_values(self):
+        """Return a dictionary of key/values in the payload received from
+           the webhook"""
         key_values = {}
         for key in self.keys:
             if key in self.payload:
                 key_values[key] = self.payload[key]
         return key_values
 
-    """This only applies to raw payloads:
-    https://sendgrid.com/docs/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.html#-Raw-Parameters"""
     def get_raw_email(self):
-        if 'email' in self.payload:
+         """This only applies to raw payloads:
+         https://sendgrid.com/docs/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.html#-Raw-Parameters"""
+         if 'email' in self.payload:
             raw_email = email.message_from_string(self.payload['email'])
             return raw_email
-        else:
+         else:
             return None
 
-    """Returns an object with:
-    type = file content type
-    file_name = the name of the file
-    contents = base64 encoded file contents"""
     def attachments(self):
-        attachments = []
+        """Returns an object with:
+        type = file content type
+        file_name = the name of the file
+        contents = base64 encoded file contents"""
+        attachments = None
         if 'attachment-info' in self.payload:
-            for _, filestorage in self.request.files.iteritems():
-                attachment = {}
-                if filestorage.filename not in (None, 'fdopen', '<fdopen>'):
-                    filename = secure_filename(filestorage.filename)
-                    attachment['type'] = filestorage.content_type
-                    attachment['file_name'] = filename
-                    attachment['contents'] = base64.b64encode(filestorage.getvalue())
-                    attachments.append(attachment)
-            return attachments
-
+            attachments = self._get_attachments(self.payload, self.request)
         # Check if we have a raw message
-        attachments = []
         raw_email = self.get_raw_email()
         if raw_email is not None:
-            counter = 1
-            for part in raw_email.walk():
-                attachment = {}
-                if part.get_content_maintype() == 'multipart':
-                    continue
-                filename = part.get_filename()
-                if not filename:
-                    ext = mimetypes.guess_extension(part.get_content_type())
-                    if not ext:
-                        ext = '.bin'
-                    filename = 'part-%03d%s' % (counter, ext)
-                counter += 1
-                attachment['type'] = part.get_content_type()
-                attachment['filename'] = filename
-                attachment['contents'] = part.get_payload(decode=False)
+            attachments = self._get_attachments_raw(self.payload)
+        return attachments
+
+    def _get_attachments(self, payload, request):
+        for _, filestorage in request.files.iteritems():
+            attachment = {}
+            if filestorage.filename not in (None, 'fdopen', '<fdopen>'):
+                filename = secure_filename(filestorage.filename)
+                attachment['type'] = filestorage.content_type
+                attachment['file_name'] = filename
+                attachment['contents'] = base64.b64encode(filestorage.getvalue())
                 attachments.append(attachment)
-            return attachments
-        return None
+        return attachments
+
+    def _get_attachments_raw(self, payload):
+        attachments = []
+        counter = 1
+        for part in raw_email.walk():
+            attachment = {}
+            if part.get_content_maintype() == 'multipart':
+                continue
+            filename = part.get_filename()
+            if not filename:
+                ext = mimetypes.guess_extension(part.get_content_type())
+                if not ext:
+                    ext = '.bin'
+                filename = 'part-%03d%s' % (counter, ext)
+            counter += 1
+            attachment['type'] = part.get_content_type()
+            attachment['filename'] = filename
+            attachment['contents'] = part.get_payload(decode=False)
+            attachments.append(attachment)
+        return attachments
 
     @property
     def keys(self):

--- a/sendgrid/helpers/inbound/parse.py
+++ b/sendgrid/helpers/inbound/parse.py
@@ -38,14 +38,15 @@ class Parse(object):
         contents = base64 encoded file contents"""
         attachments = None
         if 'attachment-info' in self.payload:
-            attachments = self._get_attachments(self.payload, self.request)
+            attachments = self._get_attachments(self.request)
         # Check if we have a raw message
         raw_email = self.get_raw_email()
         if raw_email is not None:
-            attachments = self._get_attachments_raw(self.payload)
+            attachments = self._get_attachments_raw(raw_email)
         return attachments
 
-    def _get_attachments(self, payload, request):
+    def _get_attachments(self, request):
+        attachments = []
         for _, filestorage in request.files.iteritems():
             attachment = {}
             if filestorage.filename not in (None, 'fdopen', '<fdopen>'):
@@ -56,7 +57,7 @@ class Parse(object):
                 attachments.append(attachment)
         return attachments
 
-    def _get_attachments_raw(self, payload):
+    def _get_attachments_raw(self, raw_email):
         attachments = []
         counter = 1
         for part in raw_email.walk():


### PR DESCRIPTION
Tests all passed locally;

1) Within sendgrid/helpers/inbound/parse.py - moved doc strings to be under function definitions

2) broke up `def attachments(...)` into two individual private functions, so it's a bit less cumbersome and can be individually tested better