### PR TITLE
Substitutions allow non-strings for values

### DIFF
--- a/sendgrid/helpers/mail/mail.py
+++ b/sendgrid/helpers/mail/mail.py
@@ -215,14 +215,14 @@ class Header(object):
 
 class Substitution(object):
     def __init__(self, key=None, value=None):
-        self.key = key if key != None else None
-        self.value = value if value != None else None
+        self.key = str(key) if key != None else None
+        self.value = str(value) if value != None else None
 
     def set_key(self, key):
-        self.key = key
+        self.key = str(key) if key != None else None
 
     def set_value(self, value):
-        self.value = value
+        self.value = str(value) if value != None else None
 
     def get(self):
         substitution = {}

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -51,7 +51,6 @@ class UnitTests(unittest.TestCase):
         personalization.add_header(Header("X-Mock", "true"))
         personalization.add_substitution(Substitution("%name%", "Example User"))
         personalization.add_substitution(Substitution("%city%", "Denver"))
-        personalization.add_substitution(Substitution("%year%", 2017))
         personalization.add_custom_arg(CustomArg("user_id", "343"))
         personalization.add_custom_arg(CustomArg("type", "marketing"))
         personalization.set_send_at(1443636843)

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -51,6 +51,7 @@ class UnitTests(unittest.TestCase):
         personalization.add_header(Header("X-Mock", "true"))
         personalization.add_substitution(Substitution("%name%", "Example User"))
         personalization.add_substitution(Substitution("%city%", "Denver"))
+        personalization.add_substitution(Substitution("%year%", 2017))
         personalization.add_custom_arg(CustomArg("user_id", "343"))
         personalization.add_custom_arg(CustomArg("type", "marketing"))
         personalization.set_send_at(1443636843)


### PR DESCRIPTION
Fix https://github.com/sendgrid/sendgrid-python/issues/232
