### PR TITLE
Update deprecated Heroku command

### DIFF
--- a/sendgrid/helpers/inbound/README.md
+++ b/sendgrid/helpers/inbound/README.md
@@ -91,8 +91,9 @@ To make changes: clone, modify and push the changes.
 
 For example:
 ```bash
-heroku clone -a name-of-your-app
-vim config.yml
+git clone https://github.com/sendgrid/sendgrid-python.git 
+heroku git:remote -a [name-of-your-app]
+---make changes---
 git add .
 git commit -m "update configuration"
 git push heroku master


### PR DESCRIPTION
Hi @thinkingserious,

While looking into the one-click deployment, I noticed the command `heroku clone` is deprecated. It is now `heroku git:clone`. For this example, it actually won't work. Cloning an application deployed with the platform API (in this case the Heroku Button click) clones an empty repository: https://kb.heroku.com/why-do-i-see-a-message-you-appear-to-have-cloned-an-empty-repository

The best approach is to clone the repo normally and add the remote with `heroku git:remote`

