### PR TITLE
Update sendgrid.py

### DIFF
--- a/sendgrid/sendgrid.py
+++ b/sendgrid/sendgrid.py
@@ -15,7 +15,7 @@ class SendGridAPIClient(object):
         self.path = opts.get('path', os.path.abspath(os.path.dirname(__file__)))
         self._apikey = opts.get('apikey', os.environ.get('SENDGRID_API_KEY'))
         # Support v2 api_key naming
-        self._apikey = opts.get('api_key', self._apikey)
+        self._api_key = opts.get('api_key', self._apikey)
         self._api_key = self._apikey
         self.useragent = 'sendgrid/{0};python'.format(__version__)
         self.host = opts.get('host', 'https://api.sendgrid.com')

--- a/sendgrid/sendgrid.py
+++ b/sendgrid/sendgrid.py
@@ -15,7 +15,7 @@ class SendGridAPIClient(object):
         self.path = opts.get('path', os.path.abspath(os.path.dirname(__file__)))
         self._apikey = opts.get('apikey', os.environ.get('SENDGRID_API_KEY'))
         # Support v2 api_key naming
-        self._api_key = opts.get('api_key', self._apikey)
+        self._apikey = opts.get('api_key', self._apikey)
         self._api_key = self._apikey
         self.useragent = 'sendgrid/{0};python'.format(__version__)
         self.host = opts.get('host', 'https://api.sendgrid.com')

--- a/test/test_sendgrid.py
+++ b/test/test_sendgrid.py
@@ -43,6 +43,11 @@ class UnitTests(unittest.TestCase):
         my_sendgrid = sendgrid.SendGridAPIClient(apikey="THISISMYKEY")
         self.assertEqual(my_sendgrid.apikey, "THISISMYKEY")
 
+    def test_apikey_init__webapi_v3(self):
+        # Checks if webapi v3 key gets set. 
+        my_sendgrid = sendgrid.SendGridAPIClient(apikey="__some_test_sg_webapi_v3_key_here__")
+        self.assertEqual(my_sendgrid.apikey, "__some_test_sg_webapi_v3_key_here__") 
+    
     def test_useragent(self):
         useragent = '{0}{1}{2}'.format('sendgrid/', __version__, ';python')
         self.assertEqual(self.sg.useragent, useragent)


### PR DESCRIPTION
The value of self._apikey was getting overwritten while trying to fetch v2 style "api_key" value. 
Therefore, HTTP 401 : Unauthorized error messages were seen incorrectly to the end user of this SendGrid v3 API.