### PR TITLE
Improve code quality

### DIFF
--- a/sendgrid/__init__.py
+++ b/sendgrid/__init__.py
@@ -1,4 +1,4 @@
-from .version import __version__
-#v3 API
-from .sendgrid import SendGridAPIClient
-from .helpers.mail.mail import Email
+from .version import __version__  # noqa
+# v3 API
+from .sendgrid import SendGridAPIClient  # noqa
+from .helpers.mail.mail import Email  # noqa

--- a/sendgrid/helpers/inbound/__init__.py
+++ b/sendgrid/helpers/inbound/__init__.py
@@ -1,2 +1,2 @@
-from .config import *
-from .parse import *
+from .config import *  # noqa
+from .parse import *  # noqa

--- a/sendgrid/helpers/inbound/config.py
+++ b/sendgrid/helpers/inbound/config.py
@@ -6,12 +6,14 @@ import yaml
 class Config(object):
     """All configuration for this app is loaded here"""
     def __init__(self, **opts):
-        if (os.environ.get('ENV') != 'prod'):  # We are not in Heroku
+        if os.environ.get('ENV') != 'prod':  # We are not in Heroku
             self.init_environment()
 
         """Allow variables assigned in config.yml available the following variables
            via properties"""
-        self.path = opts.get('path', os.path.abspath(os.path.dirname(__file__)))
+        self.path = opts.get(
+            'path', os.path.abspath(os.path.dirname(__file__))
+        )
         with open(self.path + '/config.yml') as stream:
             config = yaml.load(stream)
             self._debug_mode = config['debug_mode']

--- a/sendgrid/helpers/inbound/parse.py
+++ b/sendgrid/helpers/inbound/parse.py
@@ -15,8 +15,10 @@ class Parse(object):
         self._raw_payload = request.data
 
     def key_values(self):
-        """Return a dictionary of key/values in the payload received from
-           the webhook"""
+        """
+        Return a dictionary of key/values in the payload received from
+        the webhook
+        """
         key_values = {}
         for key in self.keys:
             if key in self.payload:
@@ -24,12 +26,14 @@ class Parse(object):
         return key_values
 
     def get_raw_email(self):
-         """This only applies to raw payloads:
-         https://sendgrid.com/docs/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.html#-Raw-Parameters"""
-         if 'email' in self.payload:
+        """
+        This only applies to raw payloads:
+        https://sendgrid.com/docs/Classroom/Basics/Inbound_Parse_Webhook/setting_up_the_inbound_parse_webhook.html#-Raw-Parameters
+        """
+        if 'email' in self.payload:
             raw_email = email.message_from_string(self.payload['email'])
             return raw_email
-         else:
+        else:
             return None
 
     def attachments(self):

--- a/sendgrid/helpers/inbound/send.py
+++ b/sendgrid/helpers/inbound/send.py
@@ -1,11 +1,10 @@
 """A module for sending test SendGrid Inbound Parse messages
 Usage: ./send.py [path to file containing test data]"""
 import argparse
-import os
 import sys
 try:
     from config import Config
-except:
+except ImportError:
     # Python 3+, Travis
     from sendgrid.helpers.inbound.config import Config
 from python_http_client import Client

--- a/sendgrid/helpers/mail/__init__.py
+++ b/sendgrid/helpers/mail/__init__.py
@@ -1,1 +1,1 @@
-from .mail import *
+from .mail import *  # noqa

--- a/sendgrid/helpers/mail/mail.py
+++ b/sendgrid/helpers/mail/mail.py
@@ -1,10 +1,11 @@
 """v3/mail/send response body builder"""
-import json
 
 
 class Mail(object):
     """Creates the response body for v3/mail/send"""
-    def __init__(self, from_email = None, subject = None, to_email = None, content = None):
+
+    def __init__(
+            self, from_email=None, subject=None, to_email=None, content=None):
         self.from_email = None
         self.subject = None
         self.personalizations = None
@@ -40,48 +41,67 @@ class Mail(object):
         :return: response body dict
         """
         mail = {}
-        if self.from_email != None:
+        if self.from_email is not None:
             mail["from"] = self.from_email.get()
-        if self.subject != None:
+        if self.subject is not None:
             mail["subject"] = self.subject
-        if self.personalizations != None:
-            mail["personalizations"] = [personalization.get() for personalization in self.personalizations]
-        if self.contents != None:
+
+        if self.personalizations is not None:
+            mail["personalizations"] = [
+                personalization.get()
+                for personalization in self.personalizations
+            ]
+
+        if self.contents is not None:
             mail["content"] = [ob.get() for ob in self.contents]
-        if self.attachments != None:
+
+        if self.attachments is not None:
             mail["attachments"] = [ob.get() for ob in self.attachments]
-        if self.template_id != None:
+
+        if self.template_id is not None:
             mail["template_id"] = self.template_id
-        if self.sections != None:
+
+        if self.sections is not None:
             sections = {}
             for key in self.sections:
                 sections.update(key.get())
             mail["sections"] = sections
-        if self.headers != None:
+
+        if self.headers is not None:
             headers = {}
             for key in self.headers:
                 headers.update(key.get())
             mail["headers"] = headers
-        if self.categories != None:
-            mail["categories"] = [category.get() for category in self.categories]
-        if self.custom_args != None:
+
+        if self.categories is not None:
+            mail["categories"] = [category.get() for category in
+                                  self.categories]
+
+        if self.custom_args is not None:
             custom_args = {}
             for key in self.custom_args:
                 custom_args.update(key.get())
             mail["custom_args"] = custom_args
-        if self.send_at != None:
+
+        if self.send_at is not None:
             mail["send_at"] = self.send_at
-        if self.batch_id != None:
+
+        if self.batch_id is not None:
             mail["batch_id"] = self.batch_id
-        if self.asm != None:
+
+        if self.asm is not None:
             mail["asm"] = self.asm
-        if self.ip_pool_name != None:
+
+        if self.ip_pool_name is not None:
             mail["ip_pool_name"] = self.ip_pool_name
-        if self.mail_settings != None:
+
+        if self.mail_settings is not None:
             mail["mail_settings"] = self.mail_settings.get()
-        if self.tracking_settings != None:
+
+        if self.tracking_settings is not None:
             mail["tracking_settings"] = self.tracking_settings.get()
-        if self.reply_to != None:
+
+        if self.reply_to is not None:
             mail["reply_to"] = self.reply_to.get()
         return mail
 
@@ -118,8 +138,8 @@ class Mail(object):
         if self.headers is None:
             self.headers = []
         if isinstance(header, dict):
-            (k,v) = list(header.items())[0]
-            self.headers.append(Header(k,v))
+            (k, v) = list(header.items())[0]
+            self.headers.append(Header(k, v))
         else:
             self.headers.append(header)
 
@@ -154,15 +174,17 @@ class Mail(object):
     def set_reply_to(self, reply_to):
         self.reply_to = reply_to
 
+
 ################################################################
 # The following objects are meant to be extended with validation
 ################################################################
 
 
 class Email(object):
+
     def __init__(self, email=None, name=None):
-        self.name = name if name != None else None
-        self.email = email if email != None else None
+        self.name = name if name is not None else None
+        self.email = email if email is not None else None
 
     def set_name(self, name):
         self.name = name
@@ -172,37 +194,42 @@ class Email(object):
 
     def get(self):
         email = {}
-        if self.name != None:
+        if self.name is not None:
             email["name"] = self.name
-        if self.email != None:
+
+        if self.email is not None:
             email["email"] = self.email
         return email
 
 
 class Content(object):
-    def __init__(self, type=None, value=None):
-        self.type = type if type != None else None
-        self.value = value if value != None else None
 
-    def set_type(self, type):
-        self.type = type
+    def __init__(self, type_=None, value=None):
+        self.type = type_ if type_ is not None else None
+        self.value = value if value is not None else None
+
+    def set_type(self, type_):
+        self.type = type_
 
     def set_value(self, value):
         self.value = value
 
     def get(self):
         content = {}
-        if self.type != None:
+
+        if self.type is not None:
             content["type"] = self.type
-        if self.value != None:
+
+        if self.value is not None:
             content["value"] = self.value
         return content
 
 
 class Header(object):
+
     def __init__(self, key=None, value=None):
-        self.key = key if key != None else None
-        self.value = value if value != None else None
+        self.key = key if key is not None else None
+        self.value = value if value is not None else None
 
     def set_key(self, key):
         self.key = key
@@ -212,33 +239,35 @@ class Header(object):
 
     def get(self):
         header = {}
-        if self.key != None and self.value != None:
+        if self.key is not None and self.value is not None:
             header[self.key] = self.value
         return header
 
 
 class Substitution(object):
+
     def __init__(self, key=None, value=None):
-        self.key = str(key) if key != None else None
-        self.value = str(value) if value != None else None
+        self.key = str(key) if key is not None else None
+        self.value = str(value) if value is not None else None
 
     def set_key(self, key):
-        self.key = str(key) if key != None else None
+        self.key = str(key) if key is not None else None
 
     def set_value(self, value):
-        self.value = str(value) if value != None else None
+        self.value = str(value) if value is not None else None
 
     def get(self):
         substitution = {}
-        if self.key != None and self.value != None:
+        if self.key is not None and self.value is not None:
             substitution[self.key] = self.value
         return substitution
 
 
 class Section(object):
+
     def __init__(self, key=None, value=None):
-        self.key = key if key != None else None
-        self.value = value if value != None else None
+        self.key = key if key is not None else None
+        self.value = value if value is not None else None
 
     def set_key(self, key):
         self.key = key
@@ -248,15 +277,16 @@ class Section(object):
 
     def get(self):
         section = {}
-        if self.key != None and self.value != None:
+        if self.key is not None and self.value is not None:
             section[self.key] = self.value
         return section
 
 
 class CustomArg(object):
+
     def __init__(self, key=None, value=None):
-        self.key = key if key != None else None
-        self.value = value if value != None else None
+        self.key = key if key is not None else None
+        self.value = value if value is not None else None
 
     def set_key(self, key):
         self.key = key
@@ -266,12 +296,13 @@ class CustomArg(object):
 
     def get(self):
         custom_arg = {}
-        if self.key != None and self.value != None:
+        if self.key is not None and self.value is not None:
             custom_arg[self.key] = self.value
         return custom_arg
 
 
 class Personalization(object):
+
     def __init__(self):
         self.tos = None
         self.ccs = None
@@ -320,35 +351,43 @@ class Personalization(object):
 
     def get(self):
         personalization = {}
-        if self.tos != None:
+        if self.tos is not None:
             personalization["to"] = self.tos
-        if self.ccs != None:
+
+        if self.ccs is not None:
             personalization["cc"] = self.ccs
-        if self.bccs != None:
+
+        if self.bccs is not None:
             personalization["bcc"] = self.bccs
-        if self.subject != None:
+
+        if self.subject is not None:
             personalization["subject"] = self.subject
-        if self.headers != None:
+
+        if self.headers is not None:
             headers = {}
             for key in self.headers:
                 headers.update(key)
             personalization["headers"] = headers
-        if self.substitutions != None:
+
+        if self.substitutions is not None:
             substitutions = {}
             for key in self.substitutions:
                 substitutions.update(key)
             personalization["substitutions"] = substitutions
-        if self.custom_args != None:
+
+        if self.custom_args is not None:
             custom_args = {}
             for key in self.custom_args:
                 custom_args.update(key)
             personalization["custom_args"] = custom_args
-        if self.send_at != None:
+
+        if self.send_at is not None:
             personalization["send_at"] = self.send_at
         return personalization
 
 
 class Attachment(object):
+
     def __init__(self):
         self.content = None
         self.type = None
@@ -373,70 +412,82 @@ class Attachment(object):
 
     def get(self):
         attachment = {}
-        if self.content != None:
+        if self.content is not None:
             attachment["content"] = self.content
-        if self.type != None:
+
+        if self.type is not None:
             attachment["type"] = self.type
-        if self.filename != None:
+
+        if self.filename is not None:
             attachment["filename"] = self.filename
-        if self.disposition != None:
+
+        if self.disposition is not None:
             attachment["disposition"] = self.disposition
-        if self.content_id != None:
+
+        if self.content_id is not None:
             attachment["content_id"] = self.content_id
         return attachment
 
 
 class Category(object):
+
     def __init__(self, name=None):
-        self.name = name if name != None else None
+        self.name = name if name is not None else None
 
     def get(self):
         return self.name
 
 
 class ASM(object):
+
     def __init__(self, group_id=None, groups_to_display=None):
-        self.group_id = group_id if group_id != None else None
-        self.groups_to_display = groups_to_display if groups_to_display != None else None
+        self.group_id = group_id if group_id is not None else None
+        self.groups_to_display = (
+            groups_to_display if groups_to_display is not None else None)
 
     def get(self):
         asm = {}
-        if self.group_id != None:
+        if self.group_id is not None:
             asm["group_id"] = self.group_id
-        if self.groups_to_display != None:
+
+        if self.groups_to_display is not None:
             asm["groups_to_display"] = self.groups_to_display
         return asm
 
 
 class BCCSettings(object):
+
     def __init__(self, enable=None, email=None):
-        self.enable = enable if enable != None else None
-        self.email = email if email != None else None
+        self.enable = enable if enable is not None else None
+        self.email = email if email is not None else None
 
     def get(self):
         bcc_settings = {}
-        if self.enable != None:
+        if self.enable is not None:
             bcc_settings["enable"] = self.enable
-        if self.email != None:
+
+        if self.email is not None:
             email = self.email.get()
             bcc_settings["email"] = email["email"]
         return bcc_settings
 
 
 class BypassListManagement(object):
+
     def __init__(self, enable=None):
-        self.enable = enable if enable != None else None
+        self.enable = enable if enable is not None else None
 
     def get(self):
         bypass_list_management = {}
-        if self.enable != None:
+        if self.enable is not None:
             bypass_list_management["enable"] = self.enable
         return bypass_list_management
 
 
 class FooterSettings(object):
+
     def __init__(self, enable=None, text=None, html=None):
-        self.enable = enable if enable != None else None
+        self.enable = enable if enable is not None else None
         self.text = text if text else text
         self.html = html if html else html
 
@@ -451,31 +502,35 @@ class FooterSettings(object):
 
     def get(self):
         footer_settings = {}
-        if self.enable != None:
+        if self.enable is not None:
             footer_settings["enable"] = self.enable
-        if self.text != None:
+
+        if self.text is not None:
             footer_settings["text"] = self.text
-        if self.html != None:
+
+        if self.html is not None:
             footer_settings["html"] = self.html
         return footer_settings
 
 
 class SandBoxMode(object):
+
     def __init__(self, enable=None):
         self.enable = enable if enable else False
 
     def get(self):
         sandbox_mode = {}
-        if self.enable != None:
+        if self.enable is not None:
             sandbox_mode["enable"] = self.enable
         return sandbox_mode
 
 
 class SpamCheck(object):
+
     def __init__(self, enable=None, threshold=None, post_to_url=None):
-        self.enable = enable if enable != None else None
-        self.threshold = threshold if threshold != None else None
-        self.post_to_url = post_to_url if post_to_url != None else None
+        self.enable = enable if enable is not None else None
+        self.threshold = threshold if threshold is not None else None
+        self.post_to_url = post_to_url if post_to_url is not None else None
 
     def set_enable(self, enable):
         self.enable = enable
@@ -488,16 +543,17 @@ class SpamCheck(object):
 
     def get(self):
         spam_check = {}
-        if self.enable != None:
+        if self.enable is not None:
             spam_check["enable"] = self.enable
-        if self.threshold != None:
+        if self.threshold is not None:
             spam_check["threshold"] = self.threshold
-        if self.post_to_url != None:
+        if self.post_to_url is not None:
             spam_check["post_to_url"] = self.post_to_url
         return spam_check
 
 
 class MailSettings(object):
+
     def __init__(self):
         self.bcc_settings = None
         self.bypass_list_management = None
@@ -522,23 +578,25 @@ class MailSettings(object):
 
     def get(self):
         mail_settings = {}
-        if self.bcc_settings != None:
+        if self.bcc_settings is not None:
             mail_settings["bcc"] = self.bcc_settings.get()
-        if self.bypass_list_management != None:
-            mail_settings["bypass_list_management"] = self.bypass_list_management.get()
-        if self.footer_settings != None:
+        if self.bypass_list_management is not None:
+            mail_settings[
+                "bypass_list_management"] = self.bypass_list_management.get()
+        if self.footer_settings is not None:
             mail_settings["footer"] = self.footer_settings.get()
-        if self.sandbox_mode != None:
+        if self.sandbox_mode is not None:
             mail_settings["sandbox_mode"] = self.sandbox_mode.get()
-        if self.spam_check != None:
+        if self.spam_check is not None:
             mail_settings["spam_check"] = self.spam_check.get()
         return mail_settings
 
 
 class ClickTracking(object):
+
     def __init__(self, enable=None, enable_text=None):
         self.enable = enable if enable else None
-        self.enable_text = enable_text if enable_text !=None else None
+        self.enable_text = enable_text if enable_text is not None else None
 
     def set_enable(self, enable):
         self.enable = enable
@@ -548,17 +606,19 @@ class ClickTracking(object):
 
     def get(self):
         click_tracking = {}
-        if self.enable != None:
+        if self.enable is not None:
             click_tracking["enable"] = self.enable
-        if self.enable_text != None:
+        if self.enable_text is not None:
             click_tracking["enable_text"] = self.enable_text
         return click_tracking
 
 
 class OpenTracking(object):
+
     def __init__(self, enable=None, substitution_tag=None):
-        self.enable = enable if enable != None else None
-        self.substitution_tag = substitution_tag if substitution_tag !=None else None
+        self.enable = enable if enable is not None else None
+        self.substitution_tag = (
+            substitution_tag if substitution_tag is not None else None)
 
     def set_enable(self, enable):
         self.enable = enable
@@ -568,19 +628,22 @@ class OpenTracking(object):
 
     def get(self):
         open_tracking = {}
-        if self.enable != None:
+        if self.enable is not None:
             open_tracking["enable"] = self.enable
-        if self.substitution_tag != None:
+        if self.substitution_tag is not None:
             open_tracking["substitution_tag"] = self.substitution_tag
         return open_tracking
 
 
 class SubscriptionTracking(object):
-    def __init__(self, enable=None, text=None, html=None, substitution_tag=None):
-        self.enable = enable if enable != None else None
-        self.text = text if text != None else None
-        self.html = html if html != None else None
-        self.substitution_tag = substitution_tag if substitution_tag != None else None
+
+    def __init__(self, enable=None, text=None, html=None,
+                 substitution_tag=None):
+        self.enable = enable if enable is not None else None
+        self.text = text if text is not None else None
+        self.html = html if html is not None else None
+        self.substitution_tag = (
+            substitution_tag if substitution_tag is not None else None)
 
     def set_enable(self, enable):
         self.enable = enable
@@ -596,18 +659,19 @@ class SubscriptionTracking(object):
 
     def get(self):
         subscription_tracking = {}
-        if self.enable != None:
+        if self.enable is not None:
             subscription_tracking["enable"] = self.enable
-        if self.text != None:
+        if self.text is not None:
             subscription_tracking["text"] = self.text
-        if self.html != None:
+        if self.html is not None:
             subscription_tracking["html"] = self.html
-        if self.substitution_tag != None:
+        if self.substitution_tag is not None:
             subscription_tracking["substitution_tag"] = self.substitution_tag
         return subscription_tracking
 
 
 class Ganalytics(object):
+
     def __init__(self,
                  enable=None,
                  utm_source=None,
@@ -615,12 +679,12 @@ class Ganalytics(object):
                  utm_term=None,
                  utm_content=None,
                  utm_campaign=None):
-        self.enable = enable if enable != None else None
-        self.utm_source = utm_source if utm_source != None else None
-        self.utm_medium = utm_medium if utm_medium != None else None
-        self.utm_term = utm_term if utm_term != None else None
-        self.utm_content = utm_content if utm_content != None else None
-        self.utm_campaign = utm_campaign if utm_campaign != None else None
+        self.enable = enable if enable is not None else None
+        self.utm_source = utm_source if utm_source is not None else None
+        self.utm_medium = utm_medium if utm_medium is not None else None
+        self.utm_term = utm_term if utm_term is not None else None
+        self.utm_content = utm_content if utm_content is not None else None
+        self.utm_campaign = utm_campaign if utm_campaign is not None else None
 
     def set_enable(self, enable):
         self.enable = enable
@@ -642,22 +706,23 @@ class Ganalytics(object):
 
     def get(self):
         ganalytics = {}
-        if self.enable != None:
+        if self.enable is not None:
             ganalytics["enable"] = self.enable
-        if self.utm_source != None:
+        if self.utm_source is not None:
             ganalytics["utm_source"] = self.utm_source
-        if self.utm_medium != None:
+        if self.utm_medium is not None:
             ganalytics["utm_medium"] = self.utm_medium
-        if self.utm_term != None:
+        if self.utm_term is not None:
             ganalytics["utm_term"] = self.utm_term
-        if self.utm_content != None:
+        if self.utm_content is not None:
             ganalytics["utm_content"] = self.utm_content
-        if self.utm_campaign != None:
+        if self.utm_campaign is not None:
             ganalytics["utm_campaign"] = self.utm_campaign
         return ganalytics
 
 
 class TrackingSettings(object):
+
     def __init__(self):
         self.click_tracking = None
         self.open_tracking = None
@@ -678,12 +743,13 @@ class TrackingSettings(object):
 
     def get(self):
         tracking_settings = {}
-        if self.click_tracking != None:
+        if self.click_tracking is not None:
             tracking_settings["click_tracking"] = self.click_tracking.get()
-        if self.open_tracking != None:
+        if self.open_tracking is not None:
             tracking_settings["open_tracking"] = self.open_tracking.get()
-        if self.subscription_tracking != None:
-            tracking_settings["subscription_tracking"] = self.subscription_tracking.get()
-        if self.ganalytics != None:
+        if self.subscription_tracking is not None:
+            tracking_settings[
+                "subscription_tracking"] = self.subscription_tracking.get()
+        if self.ganalytics is not None:
             tracking_settings["ganalytics"] = self.ganalytics.get()
         return tracking_settings

--- a/sendgrid/sendgrid.py
+++ b/sendgrid/sendgrid.py
@@ -3,8 +3,10 @@ import python_http_client
 
 from .version import __version__
 
+
 class SendGridAPIClient(object):
     """SendGrid API."""
+
     def __init__(self, **opts):
         """
         Construct SendGrid v3 API object.
@@ -12,7 +14,8 @@ class SendGridAPIClient(object):
         :params host: Base URL for the API call
         :type host: string
         """
-        self.path = opts.get('path', os.path.abspath(os.path.dirname(__file__)))
+        self.path = opts.get(
+            'path', os.path.abspath(os.path.dirname(__file__)))
         self._apikey = opts.get('apikey', os.environ.get('SENDGRID_API_KEY'))
         # Support v2 api_key naming
         self._apikey = opts.get('api_key', self._apikey)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ long_description = 'Please see our GitHub README'
 if os.path.exists('README.txt'):
     long_description = open('README.txt').read()
 
+
 def getRequires():
     deps = ['python_http_client>=2.1.1']
     if sys.version_info < (2, 7):

--- a/test/prism.sh
+++ b/test/prism.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 install () {
 
@@ -25,15 +25,16 @@ elif [ "$UNAME" = "Linux" ] ; then
   fi
 fi
 
-LATEST=$(curl -s https://api.github.com/repos/stoplightio/prism/tags | grep -Eo '"name":.*?[^\\]",'  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
+#LATEST=$(curl -s https://api.github.com/repos/stoplightio/prism/tags | grep -Eo '"name":.*?[^\\]",'  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
+LATEST="v0.1.5"
 URL="https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
-DEST=/usr/local/bin/prism
+DEST=./prism/bin/prism
 
 if [ -z $LATEST ] ; then
   echo "Error requesting. Download binary from ${URL}"
   exit 1
 else
-  curl -sL $URL -o $DEST
+  curl -L $URL -o $DEST
   chmod +x $DEST
 fi
 }

--- a/test/prism.sh
+++ b/test/prism.sh
@@ -1,48 +1,41 @@
 #!/bin/sh
 
-install() {
+install () {
 
-    set - eu
+set -eu
 
-    UNAME =$(uname)
-    ARCH =$(uname - m)
-    if ["$UNAME" != "Linux"] & & ["$UNAME" != "Darwin"] & & ["$ARCH" != "x86_64"] & & ["$ARCH" != "i686"]
-    then
+UNAME=$(uname)
+ARCH=$(uname -m)
+if [ "$UNAME" != "Linux" ] && [ "$UNAME" != "Darwin" ] && [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "i686" ]; then
     echo "Sorry, OS/Architecture not supported: ${UNAME}/${ARCH}. Download binary from https://github.com/stoplightio/prism/releases"
     exit 1
-    fi
+fi
 
-    if ["$UNAME" = "Darwin"]
-    then
-    OSX_ARCH =$(uname - m)
-    if ["${OSX_ARCH}" = "x86_64"]
-    then
-    PLATFORM = "darwin_amd64"
-    fi
-    elif ["$UNAME" = "Linux"]
-    then
-    LINUX_ARCH =$(uname - m)
-    if ["${LINUX_ARCH}" = "i686"]
-    then
-    PLATFORM = "linux_386"
-    elif ["${LINUX_ARCH}" = "x86_64"]
-    then
-    PLATFORM = "linux_amd64"
-    fi
-    fi
+if [ "$UNAME" = "Darwin" ] ; then
+  OSX_ARCH=$(uname -m)
+  if [ "${OSX_ARCH}" = "x86_64" ] ; then
+    PLATFORM="darwin_amd64"
+  fi
+elif [ "$UNAME" = "Linux" ] ; then
+  LINUX_ARCH=$(uname -m)
+  if [ "${LINUX_ARCH}" = "i686" ] ; then
+    PLATFORM="linux_386"
+  elif [ "${LINUX_ARCH}" = "x86_64" ] ; then
+    PLATFORM="linux_amd64"
+  fi
+fi
 
-    LATEST =$(curl - s https: // api.github.com / repos / stoplightio / prism / tags | grep - Eo '"name":.*?[^\\]",' | head - n 1 | sed 's/[," ]//g' | cut - d ':' - f 2)
-    URL = "https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
-    DEST = /usr / local / bin / prism
+LATEST=$(curl -s https://api.github.com/repos/stoplightio/prism/tags | grep -Eo '"name":.*?[^\\]",'  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
+URL="https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
+DEST=/usr/local/bin/prism
 
-    if [-z $LATEST]
-    then
-    echo "Error requesting. Download binary from ${URL}"
-    exit 1
-    else
-    curl - sL $URL - o $DEST
-    chmod + x $DEST
-    fi
+if [ -z $LATEST ] ; then
+  echo "Error requesting. Download binary from ${URL}"
+  exit 1
+else
+  curl -sL $URL -o $DEST
+  chmod +x $DEST
+fi
 }
 
 install

--- a/test/prism.sh
+++ b/test/prism.sh
@@ -1,42 +1,48 @@
-#!/bin/bash
+#!/bin/sh
 
-install () {
+install() {
 
-set -eu
+    set - eu
 
-UNAME=$(uname)
-ARCH=$(uname -m)
-if [ "$UNAME" != "Linux" ] && [ "$UNAME" != "Darwin" ] && [ "$ARCH" != "x86_64" ] && [ "$ARCH" != "i686" ]; then
+    UNAME =$(uname)
+    ARCH =$(uname - m)
+    if ["$UNAME" != "Linux"] & & ["$UNAME" != "Darwin"] & & ["$ARCH" != "x86_64"] & & ["$ARCH" != "i686"]
+    then
     echo "Sorry, OS/Architecture not supported: ${UNAME}/${ARCH}. Download binary from https://github.com/stoplightio/prism/releases"
     exit 1
-fi
+    fi
 
-if [ "$UNAME" = "Darwin" ] ; then
-  OSX_ARCH=$(uname -m)
-  if [ "${OSX_ARCH}" = "x86_64" ] ; then
-    PLATFORM="darwin_amd64"
-  fi
-elif [ "$UNAME" = "Linux" ] ; then
-  LINUX_ARCH=$(uname -m)
-  if [ "${LINUX_ARCH}" = "i686" ] ; then
-    PLATFORM="linux_386"
-  elif [ "${LINUX_ARCH}" = "x86_64" ] ; then
-    PLATFORM="linux_amd64"
-  fi
-fi
+    if ["$UNAME" = "Darwin"]
+    then
+    OSX_ARCH =$(uname - m)
+    if ["${OSX_ARCH}" = "x86_64"]
+    then
+    PLATFORM = "darwin_amd64"
+    fi
+    elif ["$UNAME" = "Linux"]
+    then
+    LINUX_ARCH =$(uname - m)
+    if ["${LINUX_ARCH}" = "i686"]
+    then
+    PLATFORM = "linux_386"
+    elif ["${LINUX_ARCH}" = "x86_64"]
+    then
+    PLATFORM = "linux_amd64"
+    fi
+    fi
 
-#LATEST=$(curl -s https://api.github.com/repos/stoplightio/prism/tags | grep -Eo '"name":.*?[^\\]",'  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
-LATEST="v0.1.5"
-URL="https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
-DEST=./prism/bin/prism
+    LATEST =$(curl - s https: // api.github.com / repos / stoplightio / prism / tags | grep - Eo '"name":.*?[^\\]",' | head - n 1 | sed 's/[," ]//g' | cut - d ':' - f 2)
+    URL = "https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
+    DEST = /usr / local / bin / prism
 
-if [ -z $LATEST ] ; then
-  echo "Error requesting. Download binary from ${URL}"
-  exit 1
-else
-  curl -L $URL -o $DEST
-  chmod +x $DEST
-fi
+    if [-z $LATEST]
+    then
+    echo "Error requesting. Download binary from ${URL}"
+    exit 1
+    else
+    curl - sL $URL - o $DEST
+    chmod + x $DEST
+    fi
 }
 
 install

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -6,6 +6,7 @@ except ImportError:
 
 
 class UnitTests(unittest.TestCase):
+
     def setUp(self):
         self.config = Config()
 

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -1,7 +1,30 @@
-import sendgrid
 import json
-from sendgrid.helpers.mail import *
-from sendgrid.version import __version__
+
+from sendgrid.helpers.mail import (
+    ASM,
+    Attachment,
+    BCCSettings,
+    BypassListManagement,
+    Category,
+    ClickTracking,
+    Content,
+    CustomArg,
+    Email,
+    FooterSettings,
+    Ganalytics,
+    Header,
+    Mail,
+    MailSettings,
+    OpenTracking,
+    Personalization,
+    SandBoxMode,
+    Section,
+    SpamCheck,
+    SubscriptionTracking,
+    Substitution,
+    TrackingSettings
+)
+
 try:
     import unittest2 as unittest
 except ImportError:
@@ -9,7 +32,6 @@ except ImportError:
 
 
 class UnitTests(unittest.TestCase):
-
     def test_helloEmail(self):
         self.maxDiff = None
 
@@ -34,7 +56,13 @@ class UnitTests(unittest.TestCase):
             json.dumps(
                 mail.get(),
                 sort_keys=True),
-            '{"content": [{"type": "text/plain", "value": "some text here"}, {"type": "text/html", "value": "<html><body>some text here</body></html>"}], "from": {"email": "test@example.com"}, "personalizations": [{"to": [{"email": "test@example.com"}]}], "subject": "Hello World from the SendGrid Python Library"}')
+            '{"content": [{"type": "text/plain", "value": "some text here"}, '
+            '{"type": "text/html", '
+            '"value": "<html><body>some text here</body></html>"}], '
+            '"from": {"email": "test@example.com"}, "personalizations": '
+            '[{"to": [{"email": "test@example.com"}]}], '
+            '"subject": "Hello World from the SendGrid Python Library"}'
+        )
 
     def test_kitchenSink(self):
         self.maxDiff = None
@@ -92,7 +120,8 @@ class UnitTests(unittest.TestCase):
 
         attachment = Attachment()
         attachment.set_content(
-            "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12")
+            "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2N"
+            "pbmcgZWxpdC4gQ3JhcyBwdW12")
         attachment.set_type("application/pdf")
         attachment.set_filename("balance_001.pdf")
         attachment.set_disposition("attachment")
@@ -156,13 +185,16 @@ class UnitTests(unittest.TestCase):
         tracking_settings.set_open_tracking(
             OpenTracking(
                 True,
-                "Optional tag to replace with the open image in the body of the message"))
+                "Optional tag to replace with the open image in the body "
+                "of the message"))
         tracking_settings.set_subscription_tracking(
             SubscriptionTracking(
                 True,
                 "text to insert into the text/plain portion of the message",
-                "<html><body>html to insert into the text/html portion of the message</body></html>",
-                "Optional tag to replace with the open image in the body of the message"))
+                "<html><body>html to insert into the text/html portion of the "
+                "message</body></html>",
+                "Optional tag to replace with the open image in the body of "
+                "the message"))
         tracking_settings.set_ganalytics(
             Ganalytics(
                 True,
@@ -175,4 +207,6 @@ class UnitTests(unittest.TestCase):
 
         mail.set_reply_to(Email("test@example.com"))
 
-        self.assertEqual(json.dumps(mail.get(), sort_keys=True), '{"asm": {"group_id": 99, "groups_to_display": [4, 5, 6, 7, 8]}, "attachments": [{"content": "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12", "content_id": "Balance Sheet", "disposition": "attachment", "filename": "balance_001.pdf", "type": "application/pdf"}, {"content": "BwdW", "content_id": "Banner", "disposition": "inline", "filename": "banner.png", "type": "image/png"}], "batch_id": "sendgrid_batch_id", "categories": ["May", "2016"], "content": [{"type": "text/plain", "value": "some text here"}, {"type": "text/html", "value": "<html><body>some text here</body></html>"}], "custom_args": {"campaign": "welcome", "weekday": "morning"}, "from": {"email": "test@example.com", "name": "Example User"}, "headers": {"X-Test1": "test1", "X-Test3": "test2", "X-Test4": "test4"}, "ip_pool_name": "24", "mail_settings": {"bcc": {"email": "test@example.com", "enable": true}, "bypass_list_management": {"enable": true}, "footer": {"enable": true, "html": "<html><body>Footer Text</body></html>", "text": "Footer Text"}, "sandbox_mode": {"enable": true}, "spam_check": {"enable": true, "post_to_url": "https://spamcatcher.sendgrid.com", "threshold": 1}}, "personalizations": [{"bcc": [{"email": "test@example.com"}, {"email": "test@example.com"}], "cc": [{"email": "test@example.com", "name": "Example User"}, {"email": "test@example.com", "name": "Example User"}], "custom_args": {"type": "marketing", "user_id": "343"}, "headers": {"X-Mock": "true", "X-Test": "test"}, "send_at": 1443636843, "subject": "Hello World from the Personalized SendGrid Python Library", "substitutions": {"%city%": "Denver", "%name%": "Example User"}, "to": [{"email": "test@example.com", "name": "Example User"}, {"email": "test@example.com", "name": "Example User"}]}, {"bcc": [{"email": "test@example.com"}, {"email": "test@example.com"}], "cc": [{"email": "test@example.com", "name": "Example User"}, {"email": "test@example.com", "name": "Example User"}], "custom_args": {"type": "marketing", "user_id": "343"}, "headers": {"X-Mock": "true", "X-Test": "test"}, "send_at": 1443636843, "subject": "Hello World from the Personalized SendGrid Python Library", "substitutions": {"%city%": "Denver", "%name%": "Example User"}, "to": [{"email": "test@example.com", "name": "Example User"}, {"email": "test@example.com", "name": "Example User"}]}], "reply_to": {"email": "test@example.com"}, "sections": {"%section1%": "Substitution Text for Section 1", "%section2%": "Substitution Text for Section 2"}, "send_at": 1443636842, "subject": "Hello World from the SendGrid Python Library", "template_id": "13b8f94f-bcae-4ec6-b752-70d6cb59f932", "tracking_settings": {"click_tracking": {"enable": true, "enable_text": true}, "ganalytics": {"enable": true, "utm_campaign": "some campaign", "utm_content": "some content", "utm_medium": "some medium", "utm_source": "some source", "utm_term": "some term"}, "open_tracking": {"enable": true, "substitution_tag": "Optional tag to replace with the open image in the body of the message"}, "subscription_tracking": {"enable": true, "html": "<html><body>html to insert into the text/html portion of the message</body></html>", "substitution_tag": "Optional tag to replace with the open image in the body of the message", "text": "text to insert into the text/plain portion of the message"}}}')
+        self.assertEqual(
+            json.dumps(mail.get(), sort_keys=True),
+            '{"asm": {"group_id": 99, "groups_to_display": [4, 5, 6, 7, 8]}, "attachments": [{"content": "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12", "content_id": "Balance Sheet", "disposition": "attachment", "filename": "balance_001.pdf", "type": "application/pdf"}, {"content": "BwdW", "content_id": "Banner", "disposition": "inline", "filename": "banner.png", "type": "image/png"}], "batch_id": "sendgrid_batch_id", "categories": ["May", "2016"], "content": [{"type": "text/plain", "value": "some text here"}, {"type": "text/html", "value": "<html><body>some text here</body></html>"}], "custom_args": {"campaign": "welcome", "weekday": "morning"}, "from": {"email": "test@example.com", "name": "Example User"}, "headers": {"X-Test1": "test1", "X-Test3": "test2", "X-Test4": "test4"}, "ip_pool_name": "24", "mail_settings": {"bcc": {"email": "test@example.com", "enable": true}, "bypass_list_management": {"enable": true}, "footer": {"enable": true, "html": "<html><body>Footer Text</body></html>", "text": "Footer Text"}, "sandbox_mode": {"enable": true}, "spam_check": {"enable": true, "post_to_url": "https://spamcatcher.sendgrid.com", "threshold": 1}}, "personalizations": [{"bcc": [{"email": "test@example.com"}, {"email": "test@example.com"}], "cc": [{"email": "test@example.com", "name": "Example User"}, {"email": "test@example.com", "name": "Example User"}], "custom_args": {"type": "marketing", "user_id": "343"}, "headers": {"X-Mock": "true", "X-Test": "test"}, "send_at": 1443636843, "subject": "Hello World from the Personalized SendGrid Python Library", "substitutions": {"%city%": "Denver", "%name%": "Example User"}, "to": [{"email": "test@example.com", "name": "Example User"}, {"email": "test@example.com", "name": "Example User"}]}, {"bcc": [{"email": "test@example.com"}, {"email": "test@example.com"}], "cc": [{"email": "test@example.com", "name": "Example User"}, {"email": "test@example.com", "name": "Example User"}], "custom_args": {"type": "marketing", "user_id": "343"}, "headers": {"X-Mock": "true", "X-Test": "test"}, "send_at": 1443636843, "subject": "Hello World from the Personalized SendGrid Python Library", "substitutions": {"%city%": "Denver", "%name%": "Example User"}, "to": [{"email": "test@example.com", "name": "Example User"}, {"email": "test@example.com", "name": "Example User"}]}], "reply_to": {"email": "test@example.com"}, "sections": {"%section1%": "Substitution Text for Section 1", "%section2%": "Substitution Text for Section 2"}, "send_at": 1443636842, "subject": "Hello World from the SendGrid Python Library", "template_id": "13b8f94f-bcae-4ec6-b752-70d6cb59f932", "tracking_settings": {"click_tracking": {"enable": true, "enable_text": true}, "ganalytics": {"enable": true, "utm_campaign": "some campaign", "utm_content": "some content", "utm_medium": "some medium", "utm_source": "some source", "utm_term": "some term"}, "open_tracking": {"enable": true, "substitution_tag": "Optional tag to replace with the open image in the body of the message"}, "subscription_tracking": {"enable": true, "html": "<html><body>html to insert into the text/html portion of the message</body></html>", "substitution_tag": "Optional tag to replace with the open image in the body of the message", "text": "text to insert into the text/plain portion of the message"}}}')

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -25,9 +25,16 @@ class UnitTests(unittest.TestCase):
         mail.add_personalization(personalization)
 
         mail.add_content(Content("text/plain", "some text here"))
-        mail.add_content(Content("text/html", "<html><body>some text here</body></html>"))
+        mail.add_content(
+            Content(
+                "text/html",
+                "<html><body>some text here</body></html>"))
 
-        self.assertEqual(json.dumps(mail.get(), sort_keys=True), '{"content": [{"type": "text/plain", "value": "some text here"}, {"type": "text/html", "value": "<html><body>some text here</body></html>"}], "from": {"email": "test@example.com"}, "personalizations": [{"to": [{"email": "test@example.com"}]}], "subject": "Hello World from the SendGrid Python Library"}')
+        self.assertEqual(
+            json.dumps(
+                mail.get(),
+                sort_keys=True),
+            '{"content": [{"type": "text/plain", "value": "some text here"}, {"type": "text/html", "value": "<html><body>some text here</body></html>"}], "from": {"email": "test@example.com"}, "personalizations": [{"to": [{"email": "test@example.com"}]}], "subject": "Hello World from the SendGrid Python Library"}')
 
     def test_kitchenSink(self):
         self.maxDiff = None
@@ -46,10 +53,12 @@ class UnitTests(unittest.TestCase):
         personalization.add_cc(Email("test@example.com", "Example User"))
         personalization.add_bcc(Email("test@example.com"))
         personalization.add_bcc(Email("test@example.com"))
-        personalization.set_subject("Hello World from the Personalized SendGrid Python Library")
+        personalization.set_subject(
+            "Hello World from the Personalized SendGrid Python Library")
         personalization.add_header(Header("X-Test", "test"))
         personalization.add_header(Header("X-Mock", "true"))
-        personalization.add_substitution(Substitution("%name%", "Example User"))
+        personalization.add_substitution(
+            Substitution("%name%", "Example User"))
         personalization.add_substitution(Substitution("%city%", "Denver"))
         personalization.add_custom_arg(CustomArg("user_id", "343"))
         personalization.add_custom_arg(CustomArg("type", "marketing"))
@@ -63,10 +72,12 @@ class UnitTests(unittest.TestCase):
         personalization2.add_cc(Email("test@example.com", "Example User"))
         personalization2.add_bcc(Email("test@example.com"))
         personalization2.add_bcc(Email("test@example.com"))
-        personalization2.set_subject("Hello World from the Personalized SendGrid Python Library")
+        personalization2.set_subject(
+            "Hello World from the Personalized SendGrid Python Library")
         personalization2.add_header(Header("X-Test", "test"))
         personalization2.add_header(Header("X-Mock", "true"))
-        personalization2.add_substitution(Substitution("%name%", "Example User"))
+        personalization2.add_substitution(
+            Substitution("%name%", "Example User"))
         personalization2.add_substitution(Substitution("%city%", "Denver"))
         personalization2.add_custom_arg(CustomArg("user_id", "343"))
         personalization2.add_custom_arg(CustomArg("type", "marketing"))
@@ -74,10 +85,14 @@ class UnitTests(unittest.TestCase):
         mail.add_personalization(personalization2)
 
         mail.add_content(Content("text/plain", "some text here"))
-        mail.add_content(Content("text/html", "<html><body>some text here</body></html>"))
+        mail.add_content(
+            Content(
+                "text/html",
+                "<html><body>some text here</body></html>"))
 
         attachment = Attachment()
-        attachment.set_content("TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12")
+        attachment.set_content(
+            "TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQ3JhcyBwdW12")
         attachment.set_type("application/pdf")
         attachment.set_filename("balance_001.pdf")
         attachment.set_disposition("attachment")
@@ -94,13 +109,19 @@ class UnitTests(unittest.TestCase):
 
         mail.set_template_id("13b8f94f-bcae-4ec6-b752-70d6cb59f932")
 
-        mail.add_section(Section("%section1%", "Substitution Text for Section 1"))
-        mail.add_section(Section("%section2%", "Substitution Text for Section 2"))
+        mail.add_section(
+            Section(
+                "%section1%",
+                "Substitution Text for Section 1"))
+        mail.add_section(
+            Section(
+                "%section2%",
+                "Substitution Text for Section 2"))
 
         mail.add_header(Header("X-Test1", "test1"))
         mail.add_header(Header("X-Test3", "test2"))
 
-        mail.add_header({"X-Test4" : "test4"})
+        mail.add_header({"X-Test4": "test4"})
 
         mail.add_category(Category("May"))
         mail.add_category(Category("2016"))
@@ -117,18 +138,39 @@ class UnitTests(unittest.TestCase):
         mail.set_ip_pool_name("24")
 
         mail_settings = MailSettings()
-        mail_settings.set_bcc_settings(BCCSettings(True, Email("test@example.com")))
+        mail_settings.set_bcc_settings(
+            BCCSettings(True, Email("test@example.com")))
         mail_settings.set_bypass_list_management(BypassListManagement(True))
-        mail_settings.set_footer_settings(FooterSettings(True, "Footer Text", "<html><body>Footer Text</body></html>"))
+        mail_settings.set_footer_settings(
+            FooterSettings(
+                True,
+                "Footer Text",
+                "<html><body>Footer Text</body></html>"))
         mail_settings.set_sandbox_mode(SandBoxMode(True))
-        mail_settings.set_spam_check(SpamCheck(True, 1, "https://spamcatcher.sendgrid.com"))
+        mail_settings.set_spam_check(
+            SpamCheck(True, 1, "https://spamcatcher.sendgrid.com"))
         mail.set_mail_settings(mail_settings)
 
         tracking_settings = TrackingSettings()
         tracking_settings.set_click_tracking(ClickTracking(True, True))
-        tracking_settings.set_open_tracking(OpenTracking(True, "Optional tag to replace with the open image in the body of the message"))
-        tracking_settings.set_subscription_tracking(SubscriptionTracking(True, "text to insert into the text/plain portion of the message", "<html><body>html to insert into the text/html portion of the message</body></html>", "Optional tag to replace with the open image in the body of the message"))
-        tracking_settings.set_ganalytics(Ganalytics(True, "some source", "some medium", "some term", "some content", "some campaign"))
+        tracking_settings.set_open_tracking(
+            OpenTracking(
+                True,
+                "Optional tag to replace with the open image in the body of the message"))
+        tracking_settings.set_subscription_tracking(
+            SubscriptionTracking(
+                True,
+                "text to insert into the text/plain portion of the message",
+                "<html><body>html to insert into the text/html portion of the message</body></html>",
+                "Optional tag to replace with the open image in the body of the message"))
+        tracking_settings.set_ganalytics(
+            Ganalytics(
+                True,
+                "some source",
+                "some medium",
+                "some term",
+                "some content",
+                "some campaign"))
         mail.set_tracking_settings(tracking_settings)
 
         mail.set_reply_to(Email("test@example.com"))

--- a/test/test_parse.py
+++ b/test/test_parse.py
@@ -6,11 +6,14 @@ try:
 except ImportError:
     import unittest
 
+
 class UnitTests(unittest.TestCase):
+
     def setUp(self):
         self.config = Config()
         self.tester = app.test_client(self)
 
     def test_parse(self):
-        response = self.tester.post(self.config.endpoint, data='{"Message:", "Success"}')
+        response = self.tester.post(self.config.endpoint,
+                                    data='{"Message:", "Success"}')
         self.assertEqual(response.status_code, 200)

--- a/test/test_sendgrid.py
+++ b/test/test_sendgrid.py
@@ -13,26 +13,43 @@ import time
 
 host = "http://localhost:4010"
 
+
 class UnitTests(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         cls.host = host
-        cls.path = '{0}{1}'.format(os.path.abspath(os.path.dirname(__file__)), '/..')
-        cls.sg = sendgrid.SendGridAPIClient(host=host, path=cls.path, api_key=os.environ.get('SENDGRID_API_KEY'))
+        cls.path = '{0}{1}'.format(
+            os.path.abspath(
+                os.path.dirname(__file__)), '/..')
+        cls.sg = sendgrid.SendGridAPIClient(
+            host=host, path=cls.path, api_key=os.environ.get('SENDGRID_API_KEY'))
         if os.path.isfile('/usr/local/bin/prism') == False:
             if sys.platform != 'win32':
                 try:
-                    p1 = subprocess.Popen(["curl", "https://raw.githubusercontent.com/stoplightio/prism/master/install.sh"], stdout=subprocess.PIPE)
-                    p2 = subprocess.Popen(["sh"], stdin=p1.stdout, stdout=subprocess.PIPE)
+                    p1 = subprocess.Popen(
+                        [
+                            "curl",
+                            "https://raw.githubusercontent.com/stoplightio/prism/master/install.sh"],
+                        stdout=subprocess.PIPE)
+                    p2 = subprocess.Popen(
+                        ["sh"], stdin=p1.stdout, stdout=subprocess.PIPE)
                 except Exception as e:
-                    print("Error downloading the prism binary, you can try downloading directly here (https://github.com/stoplightio/prism/releases) and place in your /user/local/bin directory", e.read())
+                    print(
+                        "Error downloading the prism binary, you can try downloading directly here (https://github.com/stoplightio/prism/releases) and place in your /user/local/bin directory",
+                        e.read())
                     sys.exit()
             else:
-                print("Please download the Windows binary (https://github.com/stoplightio/prism/releases) and place it in your /usr/local/bin directory")
+                print("Please download the Windows binary "
+                      "(https://github.com/stoplightio/prism/releases) "
+                      "and place it in your /usr/local/bin directory")
                 sys.exit()
         print("Activating Prism (~20 seconds)")
         devnull = open(os.devnull, 'w')
-        cls.p = subprocess.Popen(["prism", "run", "-s", "https://raw.githubusercontent.com/sendgrid/sendgrid-oai/master/oai_stoplight.json"], stdout=devnull, stderr=subprocess.STDOUT)
+        cls.p = subprocess.Popen([
+            "prism", "run", "-s",
+            "https://raw.githubusercontent.com/sendgrid/sendgrid-oai/master/"
+            "oai_stoplight.json"], stdout=devnull, stderr=subprocess.STDOUT)
         time.sleep(15)
         print("Prism Started")
 
@@ -53,64 +70,71 @@ class UnitTests(unittest.TestCase):
     def test_access_settings_activity_get(self):
         params = {'limit': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.access_settings.activity.get(query_params=params, request_headers=headers)
+        response = self.sg.client.access_settings.activity.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_access_settings_whitelist_post(self):
         data = {
-  "ips": [
-    {
-      "ip": "192.168.1.1"
-    },
-    {
-      "ip": "192.*.*.*"
-    },
-    {
-      "ip": "192.168.1.3/32"
-    }
-  ]
-}
+            "ips": [
+                {
+                    "ip": "192.168.1.1"
+                },
+                {
+                    "ip": "192.*.*.*"
+                },
+                {
+                    "ip": "192.168.1.3/32"
+                }
+            ]
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.access_settings.whitelist.post(request_body=data, request_headers=headers)
+        response = self.sg.client.access_settings.whitelist.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_access_settings_whitelist_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.access_settings.whitelist.get(request_headers=headers)
+        response = self.sg.client.access_settings.whitelist.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_access_settings_whitelist_delete(self):
         data = {
-  "ids": [
-    1,
-    2,
-    3
-  ]
-}
+            "ids": [
+                1,
+                2,
+                3
+            ]
+        }
         headers = {'X-Mock': 204}
-        response = self.sg.client.access_settings.whitelist.delete(request_body=data, request_headers=headers)
+        response = self.sg.client.access_settings.whitelist.delete(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_access_settings_whitelist__rule_id__get(self):
         rule_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.access_settings.whitelist._(rule_id).get(request_headers=headers)
+        response = self.sg.client.access_settings.whitelist._(rule_id).get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_access_settings_whitelist__rule_id__delete(self):
         rule_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.access_settings.whitelist._(rule_id).delete(request_headers=headers)
+        response = self.sg.client.access_settings.whitelist._(rule_id).delete(
+            request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_alerts_post(self):
         data = {
-  "email_to": "example@example.com",
-  "frequency": "daily",
-  "type": "stats_notification"
-}
+            "email_to": "example@example.com",
+            "frequency": "daily",
+            "type": "stats_notification"
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.alerts.post(request_body=data, request_headers=headers)
+        response = self.sg.client.alerts.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_alerts_get(self):
@@ -120,154 +144,173 @@ class UnitTests(unittest.TestCase):
 
     def test_alerts__alert_id__patch(self):
         data = {
-  "email_to": "example@example.com"
-}
+            "email_to": "example@example.com"
+        }
         alert_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.alerts._(alert_id).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.alerts._(alert_id).patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_alerts__alert_id__get(self):
         alert_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.alerts._(alert_id).get(request_headers=headers)
+        response = self.sg.client.alerts._(alert_id).get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_alerts__alert_id__delete(self):
         alert_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.alerts._(alert_id).delete(request_headers=headers)
+        response = self.sg.client.alerts._(alert_id).delete(
+            request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_api_keys_post(self):
         data = {
-  "name": "My API Key",
-  "sample": "data",
-  "scopes": [
-    "mail.send",
-    "alerts.create",
-    "alerts.read"
-  ]
-}
+            "name": "My API Key",
+            "sample": "data",
+            "scopes": [
+                "mail.send",
+                "alerts.create",
+                "alerts.read"
+            ]
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.api_keys.post(request_body=data, request_headers=headers)
+        response = self.sg.client.api_keys.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_api_keys_get(self):
         params = {'limit': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.api_keys.get(query_params=params, request_headers=headers)
+        response = self.sg.client.api_keys.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_api_keys__api_key_id__put(self):
         data = {
-  "name": "A New Hope",
-  "scopes": [
-    "user.profile.read",
-    "user.profile.update"
-  ]
-}
+            "name": "A New Hope",
+            "scopes": [
+                "user.profile.read",
+                "user.profile.update"
+            ]
+        }
         api_key_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.api_keys._(api_key_id).put(request_body=data, request_headers=headers)
+        response = self.sg.client.api_keys._(api_key_id).put(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_api_keys__api_key_id__patch(self):
         data = {
-  "name": "A New Hope"
-}
+            "name": "A New Hope"
+        }
         api_key_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.api_keys._(api_key_id).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.api_keys._(api_key_id).patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_api_keys__api_key_id__get(self):
         api_key_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.api_keys._(api_key_id).get(request_headers=headers)
+        response = self.sg.client.api_keys._(api_key_id).get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_api_keys__api_key_id__delete(self):
         api_key_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.api_keys._(api_key_id).delete(request_headers=headers)
+        response = self.sg.client.api_keys._(api_key_id).delete(
+            request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_asm_groups_post(self):
         data = {
-  "description": "Suggestions for products our users might like.",
-  "is_default": True,
-  "name": "Product Suggestions"
-}
+            "description": "Suggestions for products our users might like.",
+            "is_default": True,
+            "name": "Product Suggestions"
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.asm.groups.post(request_body=data, request_headers=headers)
+        response = self.sg.client.asm.groups.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_asm_groups_get(self):
         params = {'id': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.asm.groups.get(query_params=params, request_headers=headers)
+        response = self.sg.client.asm.groups.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_asm_groups__group_id__patch(self):
         data = {
-  "description": "Suggestions for items our users might like.",
-  "id": 103,
-  "name": "Item Suggestions"
-}
+            "description": "Suggestions for items our users might like.",
+            "id": 103,
+            "name": "Item Suggestions"
+        }
         group_id = "test_url_param"
         headers = {'X-Mock': 201}
-        response = self.sg.client.asm.groups._(group_id).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.asm.groups._(group_id).patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_asm_groups__group_id__get(self):
         group_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.asm.groups._(group_id).get(request_headers=headers)
+        response = self.sg.client.asm.groups._(group_id).get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_asm_groups__group_id__delete(self):
         group_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.asm.groups._(group_id).delete(request_headers=headers)
+        response = self.sg.client.asm.groups._(group_id).delete(
+            request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_asm_groups__group_id__suppressions_post(self):
         data = {
-  "recipient_emails": [
-    "test1@example.com",
-    "test2@example.com"
-  ]
-}
+            "recipient_emails": [
+                "test1@example.com",
+                "test2@example.com"
+            ]
+        }
         group_id = "test_url_param"
         headers = {'X-Mock': 201}
-        response = self.sg.client.asm.groups._(group_id).suppressions.post(request_body=data, request_headers=headers)
+        response = self.sg.client.asm.groups._(group_id).suppressions.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_asm_groups__group_id__suppressions_get(self):
         group_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.asm.groups._(group_id).suppressions.get(request_headers=headers)
+        response = self.sg.client.asm.groups._(group_id).suppressions.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_asm_groups__group_id__suppressions_search_post(self):
         data = {
-  "recipient_emails": [
-    "exists1@example.com",
-    "exists2@example.com",
-    "doesnotexists@example.com"
-  ]
-}
+            "recipient_emails": [
+                "exists1@example.com",
+                "exists2@example.com",
+                "doesnotexists@example.com"
+            ]
+        }
         group_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.asm.groups._(group_id).suppressions.search.post(request_body=data, request_headers=headers)
+        response = self.sg.client.asm.groups._(
+            group_id).suppressions.search.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_asm_groups__group_id__suppressions__email__delete(self):
         group_id = "test_url_param"
         email = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.asm.groups._(group_id).suppressions._(email).delete(request_headers=headers)
+        response = self.sg.client.asm.groups._(group_id).suppressions._(
+            email).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_asm_suppressions_get(self):
@@ -277,205 +320,241 @@ class UnitTests(unittest.TestCase):
 
     def test_asm_suppressions_global_post(self):
         data = {
-  "recipient_emails": [
-    "test1@example.com",
-    "test2@example.com"
-  ]
-}
+            "recipient_emails": [
+                "test1@example.com",
+                "test2@example.com"
+            ]
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.asm.suppressions._("global").post(request_body=data, request_headers=headers)
+        response = self.sg.client.asm.suppressions._("global").post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_asm_suppressions_global__email__get(self):
         email = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.asm.suppressions._("global")._(email).get(request_headers=headers)
+        response = self.sg.client.asm.suppressions._("global")._(
+            email).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_asm_suppressions_global__email__delete(self):
         email = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.asm.suppressions._("global")._(email).delete(request_headers=headers)
+        response = self.sg.client.asm.suppressions._("global")._(
+            email).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_asm_suppressions__email__get(self):
         email = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.asm.suppressions._(email).get(request_headers=headers)
+        response = self.sg.client.asm.suppressions._(email).get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_browsers_stats_get(self):
-        params = {'end_date': '2016-04-01', 'aggregated_by': 'day', 'browsers': 'test_string', 'limit': 'test_string', 'offset': 'test_string', 'start_date': '2016-01-01'}
+        params = {'end_date': '2016-04-01', 'aggregated_by': 'day',
+                  'browsers': 'test_string', 'limit': 'test_string',
+                  'offset': 'test_string', 'start_date': '2016-01-01'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.browsers.stats.get(query_params=params, request_headers=headers)
+        response = self.sg.client.browsers.stats.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_campaigns_post(self):
         data = {
-  "categories": [
-    "spring line"
-  ],
-  "custom_unsubscribe_url": "",
-  "html_content": "<html><head><title></title></head><body><p>Check out our spring line!</p></body></html>",
-  "ip_pool": "marketing",
-  "list_ids": [
-    110,
-    124
-  ],
-  "plain_content": "Check out our spring line!",
-  "segment_ids": [
-    110
-  ],
-  "sender_id": 124451,
-  "subject": "New Products for Spring!",
-  "suppression_group_id": 42,
-  "title": "March Newsletter"
-}
+            "categories": [
+                "spring line"
+            ],
+            "custom_unsubscribe_url": "",
+            "html_content": "<html><head><title></title></head><body>"
+                            "<p>Check out our spring line!</p></body></html>",
+            "ip_pool": "marketing",
+            "list_ids": [
+                110,
+                124
+            ],
+            "plain_content": "Check out our spring line!",
+            "segment_ids": [
+                110
+            ],
+            "sender_id": 124451,
+            "subject": "New Products for Spring!",
+            "suppression_group_id": 42,
+            "title": "March Newsletter"
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.campaigns.post(request_body=data, request_headers=headers)
+        response = self.sg.client.campaigns.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_campaigns_get(self):
         params = {'limit': 1, 'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.campaigns.get(query_params=params, request_headers=headers)
+        response = self.sg.client.campaigns.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_campaigns__campaign_id__patch(self):
         data = {
-  "categories": [
-    "summer line"
-  ],
-  "html_content": "<html><head><title></title></head><body><p>Check out our summer line!</p></body></html>",
-  "plain_content": "Check out our summer line!",
-  "subject": "New Products for Summer!",
-  "title": "May Newsletter"
-}
+            "categories": [
+                "summer line"
+            ],
+            "html_content": "<html><head><title></title></head><body><p>"
+                            "Check out our summer line!</p></body></html>",
+            "plain_content": "Check out our summer line!",
+            "subject": "New Products for Summer!",
+            "title": "May Newsletter"
+        }
         campaign_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.campaigns._(campaign_id).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.campaigns._(campaign_id).patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_campaigns__campaign_id__get(self):
         campaign_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.campaigns._(campaign_id).get(request_headers=headers)
+        response = self.sg.client.campaigns._(campaign_id).get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_campaigns__campaign_id__delete(self):
         campaign_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.campaigns._(campaign_id).delete(request_headers=headers)
+        response = self.sg.client.campaigns._(campaign_id).delete(
+            request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_campaigns__campaign_id__schedules_patch(self):
         data = {
-  "send_at": 1489451436
-}
+            "send_at": 1489451436
+        }
         campaign_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.campaigns._(campaign_id).schedules.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.campaigns._(campaign_id).schedules.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_campaigns__campaign_id__schedules_post(self):
         data = {
-  "send_at": 1489771528
-}
+            "send_at": 1489771528
+        }
         campaign_id = "test_url_param"
         headers = {'X-Mock': 201}
-        response = self.sg.client.campaigns._(campaign_id).schedules.post(request_body=data, request_headers=headers)
+        response = self.sg.client.campaigns._(campaign_id).schedules.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_campaigns__campaign_id__schedules_get(self):
         campaign_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.campaigns._(campaign_id).schedules.get(request_headers=headers)
+        response = self.sg.client.campaigns._(campaign_id).schedules.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_campaigns__campaign_id__schedules_delete(self):
         campaign_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.campaigns._(campaign_id).schedules.delete(request_headers=headers)
+        response = self.sg.client.campaigns._(campaign_id).schedules.delete(
+            request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_campaigns__campaign_id__schedules_now_post(self):
         campaign_id = "test_url_param"
         headers = {'X-Mock': 201}
-        response = self.sg.client.campaigns._(campaign_id).schedules.now.post(request_headers=headers)
+        response = self.sg.client.campaigns._(campaign_id).schedules.now.post(
+            request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_campaigns__campaign_id__schedules_test_post(self):
         data = {
-  "to": "your.email@example.com"
-}
+            "to": "your.email@example.com"
+        }
         campaign_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.campaigns._(campaign_id).schedules.test.post(request_body=data, request_headers=headers)
+        response = self.sg.client.campaigns._(campaign_id).schedules.test.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_categories_get(self):
         params = {'category': 'test_string', 'limit': 1, 'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.categories.get(query_params=params, request_headers=headers)
+        response = self.sg.client.categories.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_categories_stats_get(self):
-        params = {'end_date': '2016-04-01', 'aggregated_by': 'day', 'limit': 1, 'offset': 1, 'start_date': '2016-01-01', 'categories': 'test_string'}
+        params = {'end_date': '2016-04-01', 'aggregated_by': 'day',
+                  'limit': 1, 'offset': 1, 'start_date': '2016-01-01',
+                  'categories': 'test_string'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.categories.stats.get(query_params=params, request_headers=headers)
+        response = self.sg.client.categories.stats.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_categories_stats_sums_get(self):
-        params = {'end_date': '2016-04-01', 'aggregated_by': 'day', 'limit': 1, 'sort_by_metric': 'test_string', 'offset': 1, 'start_date': '2016-01-01', 'sort_by_direction': 'asc'}
+        params = {'end_date': '2016-04-01', 'aggregated_by': 'day',
+                  'limit': 1, 'sort_by_metric': 'test_string', 'offset': 1,
+                  'start_date': '2016-01-01', 'sort_by_direction': 'asc'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.categories.stats.sums.get(query_params=params, request_headers=headers)
+        response = self.sg.client.categories.stats.sums.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_clients_stats_get(self):
-        params = {'aggregated_by': 'day', 'start_date': '2016-01-01', 'end_date': '2016-04-01'}
+        params = {'aggregated_by': 'day', 'start_date': '2016-01-01',
+                  'end_date': '2016-04-01'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.clients.stats.get(query_params=params, request_headers=headers)
+        response = self.sg.client.clients.stats.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_clients__client_type__stats_get(self):
-        params = {'aggregated_by': 'day', 'start_date': '2016-01-01', 'end_date': '2016-04-01'}
+        params = {'aggregated_by': 'day', 'start_date': '2016-01-01',
+                  'end_date': '2016-04-01'}
         client_type = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.clients._(client_type).stats.get(query_params=params, request_headers=headers)
+        response = self.sg.client.clients._(client_type).stats.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_custom_fields_post(self):
         data = {
-  "name": "pet",
-  "type": "text"
-}
+            "name": "pet",
+            "type": "text"
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.contactdb.custom_fields.post(request_body=data, request_headers=headers)
+        response = self.sg.client.contactdb.custom_fields.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_contactdb_custom_fields_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.custom_fields.get(request_headers=headers)
+        response = self.sg.client.contactdb.custom_fields.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_custom_fields__custom_field_id__get(self):
         custom_field_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.custom_fields._(custom_field_id).get(request_headers=headers)
+        response = self.sg.client.contactdb.custom_fields._(
+            custom_field_id).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_custom_fields__custom_field_id__delete(self):
         custom_field_id = "test_url_param"
         headers = {'X-Mock': 202}
-        response = self.sg.client.contactdb.custom_fields._(custom_field_id).delete(request_headers=headers)
+        response = self.sg.client.contactdb.custom_fields._(
+            custom_field_id).delete(request_headers=headers)
         self.assertEqual(response.status_code, 202)
 
     def test_contactdb_lists_post(self):
         data = {
-  "name": "your list name"
-}
+            "name": "your list name"
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.contactdb.lists.post(request_body=data, request_headers=headers)
+        response = self.sg.client.contactdb.lists.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_contactdb_lists_get(self):
@@ -485,61 +564,68 @@ class UnitTests(unittest.TestCase):
 
     def test_contactdb_lists_delete(self):
         data = [
-  1,
-  2,
-  3,
-  4
-]
+            1,
+            2,
+            3,
+            4
+        ]
         headers = {'X-Mock': 204}
-        response = self.sg.client.contactdb.lists.delete(request_body=data, request_headers=headers)
+        response = self.sg.client.contactdb.lists.delete(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_contactdb_lists__list_id__patch(self):
         data = {
-  "name": "newlistname"
-}
+            "name": "newlistname"
+        }
         params = {'list_id': 1}
         list_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.lists._(list_id).patch(request_body=data, query_params=params, request_headers=headers)
+        response = self.sg.client.contactdb.lists._(list_id).patch(
+            request_body=data, query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_lists__list_id__get(self):
         params = {'list_id': 1}
         list_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.lists._(list_id).get(query_params=params, request_headers=headers)
+        response = self.sg.client.contactdb.lists._(list_id).get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_lists__list_id__delete(self):
         params = {'delete_contacts': 'true'}
         list_id = "test_url_param"
         headers = {'X-Mock': 202}
-        response = self.sg.client.contactdb.lists._(list_id).delete(query_params=params, request_headers=headers)
+        response = self.sg.client.contactdb.lists._(list_id).delete(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 202)
 
     def test_contactdb_lists__list_id__recipients_post(self):
         data = [
-  "recipient_id1",
-  "recipient_id2"
-]
+            "recipient_id1",
+            "recipient_id2"
+        ]
         list_id = "test_url_param"
         headers = {'X-Mock': 201}
-        response = self.sg.client.contactdb.lists._(list_id).recipients.post(request_body=data, request_headers=headers)
+        response = self.sg.client.contactdb.lists._(list_id).recipients.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_contactdb_lists__list_id__recipients_get(self):
         params = {'page': 1, 'page_size': 1, 'list_id': 1}
         list_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.lists._(list_id).recipients.get(query_params=params, request_headers=headers)
+        response = self.sg.client.contactdb.lists._(list_id).recipients.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_lists__list_id__recipients__recipient_id__post(self):
         list_id = "test_url_param"
         recipient_id = "test_url_param"
         headers = {'X-Mock': 201}
-        response = self.sg.client.contactdb.lists._(list_id).recipients._(recipient_id).post(request_headers=headers)
+        response = self.sg.client.contactdb.lists._(list_id).recipients._(
+            recipient_id).post(request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_contactdb_lists__list_id__recipients__recipient_id__delete(self):
@@ -547,184 +633,222 @@ class UnitTests(unittest.TestCase):
         list_id = "test_url_param"
         recipient_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.contactdb.lists._(list_id).recipients._(recipient_id).delete(query_params=params, request_headers=headers)
+        response = self.sg.client.contactdb.lists._(list_id).recipients._(
+            recipient_id).delete(query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_contactdb_recipients_patch(self):
         data = [
-  {
-    "email": "jones@example.com",
-    "first_name": "Guy",
-    "last_name": "Jones"
-  }
-]
+            {
+                "email": "jones@example.com",
+                "first_name": "Guy",
+                "last_name": "Jones"
+            }
+        ]
         headers = {'X-Mock': 201}
-        response = self.sg.client.contactdb.recipients.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.contactdb.recipients.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_contactdb_recipients_post(self):
         data = [
-  {
-    "age": 25,
-    "email": "example@example.com",
-    "first_name": "",
-    "last_name": "User"
-  },
-  {
-    "age": 25,
-    "email": "example2@example.com",
-    "first_name": "Example",
-    "last_name": "User"
-  }
-]
+            {
+                "age": 25,
+                "email": "example@example.com",
+                "first_name": "",
+                "last_name": "User"
+            },
+            {
+                "age": 25,
+                "email": "example2@example.com",
+                "first_name": "Example",
+                "last_name": "User"
+            }
+        ]
         headers = {'X-Mock': 201}
-        response = self.sg.client.contactdb.recipients.post(request_body=data, request_headers=headers)
+        response = self.sg.client.contactdb.recipients.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_contactdb_recipients_get(self):
         params = {'page': 1, 'page_size': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.recipients.get(query_params=params, request_headers=headers)
+        response = self.sg.client.contactdb.recipients.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_recipients_delete(self):
         data = [
-  "recipient_id1",
-  "recipient_id2"
-]
+            "recipient_id1",
+            "recipient_id2"
+        ]
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.recipients.delete(request_body=data, request_headers=headers)
+        response = self.sg.client.contactdb.recipients.delete(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_recipients_billable_count_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.recipients.billable_count.get(request_headers=headers)
+        response = self.sg.client.contactdb.recipients.billable_count.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_recipients_count_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.recipients.count.get(request_headers=headers)
+        response = self.sg.client.contactdb.recipients.count.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_recipients_search_get(self):
         params = {'{field_name}': 'test_string'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.recipients.search.get(query_params=params, request_headers=headers)
+        response = self.sg.client.contactdb.recipients.search.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_recipients__recipient_id__get(self):
         recipient_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.recipients._(recipient_id).get(request_headers=headers)
+        response = self.sg.client.contactdb.recipients._(
+            recipient_id).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_recipients__recipient_id__delete(self):
         recipient_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.contactdb.recipients._(recipient_id).delete(request_headers=headers)
+        response = self.sg.client.contactdb.recipients._(
+            recipient_id).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_contactdb_recipients__recipient_id__lists_get(self):
         recipient_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.recipients._(recipient_id).lists.get(request_headers=headers)
+        response = self.sg.client.contactdb.recipients._(
+            recipient_id).lists.get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_reserved_fields_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.reserved_fields.get(request_headers=headers)
+        response = self.sg.client.contactdb.reserved_fields.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_segments_post(self):
         data = {
-  "conditions": [
-    {
-      "and_or": "",
-      "field": "last_name",
-      "operator": "eq",
-      "value": "Miller"
-    },
-    {
-      "and_or": "and",
-      "field": "last_clicked",
-      "operator": "gt",
-      "value": "01/02/2015"
-    },
-    {
-      "and_or": "or",
-      "field": "clicks.campaign_identifier",
-      "operator": "eq",
-      "value": "513"
-    }
-  ],
-  "list_id": 4,
-  "name": "Last Name Miller"
-}
+            "conditions": [
+                {
+                    "and_or": "",
+                    "field": "last_name",
+                    "operator": "eq",
+                    "value": "Miller"
+                },
+                {
+                    "and_or": "and",
+                    "field": "last_clicked",
+                    "operator": "gt",
+                    "value": "01/02/2015"
+                },
+                {
+                    "and_or": "or",
+                    "field": "clicks.campaign_identifier",
+                    "operator": "eq",
+                    "value": "513"
+                }
+            ],
+            "list_id": 4,
+            "name": "Last Name Miller"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.segments.post(request_body=data, request_headers=headers)
+        response = self.sg.client.contactdb.segments.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_segments_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.segments.get(request_headers=headers)
+        response = self.sg.client.contactdb.segments.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_segments__segment_id__patch(self):
         data = {
-  "conditions": [
-    {
-      "and_or": "",
-      "field": "last_name",
-      "operator": "eq",
-      "value": "Miller"
-    }
-  ],
-  "list_id": 5,
-  "name": "The Millers"
-}
+            "conditions": [
+                {
+                    "and_or": "",
+                    "field": "last_name",
+                    "operator": "eq",
+                    "value": "Miller"
+                }
+            ],
+            "list_id": 5,
+            "name": "The Millers"
+        }
         params = {'segment_id': 'test_string'}
         segment_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.segments._(segment_id).patch(request_body=data, query_params=params, request_headers=headers)
+        response = self.sg.client.contactdb.segments._(segment_id).patch(
+            request_body=data, query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_segments__segment_id__get(self):
         params = {'segment_id': 1}
         segment_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.segments._(segment_id).get(query_params=params, request_headers=headers)
+        response = self.sg.client.contactdb.segments._(segment_id).get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_contactdb_segments__segment_id__delete(self):
         params = {'delete_contacts': 'true'}
         segment_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.contactdb.segments._(segment_id).delete(query_params=params, request_headers=headers)
+        response = self.sg.client.contactdb.segments._(segment_id).delete(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_contactdb_segments__segment_id__recipients_get(self):
         params = {'page': 1, 'page_size': 1}
         segment_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.contactdb.segments._(segment_id).recipients.get(query_params=params, request_headers=headers)
+        response = self.sg.client.contactdb.segments._(
+            segment_id).recipients.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_devices_stats_get(self):
-        params = {'aggregated_by': 'day', 'limit': 1, 'start_date': '2016-01-01', 'end_date': '2016-04-01', 'offset': 1}
+        params = {
+            'aggregated_by': 'day',
+            'limit': 1,
+            'start_date': '2016-01-01',
+            'end_date': '2016-04-01',
+            'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.devices.stats.get(query_params=params, request_headers=headers)
+        response = self.sg.client.devices.stats.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_geo_stats_get(self):
-        params = {'end_date': '2016-04-01', 'country': 'US', 'aggregated_by': 'day', 'limit': 1, 'offset': 1, 'start_date': '2016-01-01'}
+        params = {
+            'end_date': '2016-04-01',
+            'country': 'US',
+            'aggregated_by': 'day',
+            'limit': 1,
+            'offset': 1,
+            'start_date': '2016-01-01'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.geo.stats.get(query_params=params, request_headers=headers)
+        response = self.sg.client.geo.stats.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_ips_get(self):
-        params = {'subuser': 'test_string', 'ip': 'test_string', 'limit': 1, 'exclude_whitelabels': 'true', 'offset': 1}
+        params = {
+            'subuser': 'test_string',
+            'ip': 'test_string',
+            'limit': 1,
+            'exclude_whitelabels': 'true',
+            'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.ips.get(query_params=params, request_headers=headers)
+        response = self.sg.client.ips.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_ips_assigned_get(self):
@@ -734,10 +858,11 @@ class UnitTests(unittest.TestCase):
 
     def test_ips_pools_post(self):
         data = {
-  "name": "marketing"
-}
+            "name": "marketing"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.ips.pools.post(request_body=data, request_headers=headers)
+        response = self.sg.client.ips.pools.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_ips_pools_get(self):
@@ -747,47 +872,53 @@ class UnitTests(unittest.TestCase):
 
     def test_ips_pools__pool_name__put(self):
         data = {
-  "name": "new_pool_name"
-}
+            "name": "new_pool_name"
+        }
         pool_name = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.ips.pools._(pool_name).put(request_body=data, request_headers=headers)
+        response = self.sg.client.ips.pools._(pool_name).put(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_ips_pools__pool_name__get(self):
         pool_name = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.ips.pools._(pool_name).get(request_headers=headers)
+        response = self.sg.client.ips.pools._(
+            pool_name).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_ips_pools__pool_name__delete(self):
         pool_name = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.ips.pools._(pool_name).delete(request_headers=headers)
+        response = self.sg.client.ips.pools._(
+            pool_name).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_ips_pools__pool_name__ips_post(self):
         data = {
-  "ip": "0.0.0.0"
-}
+            "ip": "0.0.0.0"
+        }
         pool_name = "test_url_param"
         headers = {'X-Mock': 201}
-        response = self.sg.client.ips.pools._(pool_name).ips.post(request_body=data, request_headers=headers)
+        response = self.sg.client.ips.pools._(pool_name).ips.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_ips_pools__pool_name__ips__ip__delete(self):
         pool_name = "test_url_param"
         ip = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.ips.pools._(pool_name).ips._(ip).delete(request_headers=headers)
+        response = self.sg.client.ips.pools._(pool_name).ips._(
+            ip).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_ips_warmup_post(self):
         data = {
-  "ip": "0.0.0.0"
-}
+            "ip": "0.0.0.0"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.ips.warmup.post(request_body=data, request_headers=headers)
+        response = self.sg.client.ips.warmup.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_ips_warmup_get(self):
@@ -798,19 +929,22 @@ class UnitTests(unittest.TestCase):
     def test_ips_warmup__ip_address__get(self):
         ip_address = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.ips.warmup._(ip_address).get(request_headers=headers)
+        response = self.sg.client.ips.warmup._(
+            ip_address).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_ips_warmup__ip_address__delete(self):
         ip_address = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.ips.warmup._(ip_address).delete(request_headers=headers)
+        response = self.sg.client.ips.warmup._(
+            ip_address).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_ips__ip_address__get(self):
         ip_address = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.ips._(ip_address).get(request_headers=headers)
+        response = self.sg.client.ips._(
+            ip_address).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_batch_post(self):
@@ -821,314 +955,350 @@ class UnitTests(unittest.TestCase):
     def test_mail_batch__batch_id__get(self):
         batch_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail.batch._(batch_id).get(request_headers=headers)
+        response = self.sg.client.mail.batch._(
+            batch_id).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_send_post(self):
         data = {
-  "asm": {
-    "group_id": 1,
-    "groups_to_display": [
-      1,
-      2,
-      3
-    ]
-  },
-  "attachments": [
-    {
-      "content": "[BASE64 encoded content block here]",
-      "content_id": "ii_139db99fdb5c3704",
-      "disposition": "inline",
-      "filename": "file1.jpg",
-      "name": "file1",
-      "type": "jpg"
-    }
-  ],
-  "batch_id": "[YOUR BATCH ID GOES HERE]",
-  "categories": [
-    "category1",
-    "category2"
-  ],
-  "content": [
-    {
-      "type": "text/html",
-      "value": "<html><p>Hello, world!</p><img src=[CID GOES HERE]></img></html>"
-    }
-  ],
-  "custom_args": {
-    "New Argument 1": "New Value 1",
-    "activationAttempt": "1",
-    "customerAccountNumber": "[CUSTOMER ACCOUNT NUMBER GOES HERE]"
-  },
-  "from": {
-    "email": "sam.smith@example.com",
-    "name": "Sam Smith"
-  },
-  "headers": {},
-  "ip_pool_name": "[YOUR POOL NAME GOES HERE]",
-  "mail_settings": {
-    "bcc": {
-      "email": "ben.doe@example.com",
-      "enable": True
-    },
-    "bypass_list_management": {
-      "enable": True
-    },
-    "footer": {
-      "enable": True,
-      "html": "<p>Thanks</br>The SendGrid Team</p>",
-      "text": "Thanks,/n The SendGrid Team"
-    },
-    "sandbox_mode": {
-      "enable": False
-    },
-    "spam_check": {
-      "enable": True,
-      "post_to_url": "http://example.com/compliance",
-      "threshold": 3
-    }
-  },
-  "personalizations": [
-    {
-      "bcc": [
-        {
-          "email": "sam.doe@example.com",
-          "name": "Sam Doe"
+            "asm": {
+                "group_id": 1,
+                "groups_to_display": [
+                    1,
+                    2,
+                    3
+                ]
+            },
+            "attachments": [
+                {
+                    "content": "[BASE64 encoded content block here]",
+                    "content_id": "ii_139db99fdb5c3704",
+                    "disposition": "inline",
+                    "filename": "file1.jpg",
+                    "name": "file1",
+                    "type": "jpg"
+                }
+            ],
+            "batch_id": "[YOUR BATCH ID GOES HERE]",
+            "categories": [
+                "category1",
+                "category2"
+            ],
+            "content": [
+                {
+                    "type": "text/html",
+                    "value": "<html><p>Hello, world!</p><img "
+                             "src=[CID GOES HERE]></img></html>"
+                }
+            ],
+            "custom_args": {
+                "New Argument 1": "New Value 1",
+                "activationAttempt": "1",
+                "customerAccountNumber": "[CUSTOMER ACCOUNT NUMBER GOES HERE]"
+            },
+            "from": {
+                "email": "sam.smith@example.com",
+                "name": "Sam Smith"
+            },
+            "headers": {},
+            "ip_pool_name": "[YOUR POOL NAME GOES HERE]",
+            "mail_settings": {
+                "bcc": {
+                    "email": "ben.doe@example.com",
+                    "enable": True
+                },
+                "bypass_list_management": {
+                    "enable": True
+                },
+                "footer": {
+                    "enable": True,
+                    "html": "<p>Thanks</br>The SendGrid Team</p>",
+                    "text": "Thanks,/n The SendGrid Team"
+                },
+                "sandbox_mode": {
+                    "enable": False
+                },
+                "spam_check": {
+                    "enable": True,
+                    "post_to_url": "http://example.com/compliance",
+                    "threshold": 3
+                }
+            },
+            "personalizations": [
+                {
+                    "bcc": [
+                        {
+                            "email": "sam.doe@example.com",
+                            "name": "Sam Doe"
+                        }
+                    ],
+                    "cc": [
+                        {
+                            "email": "jane.doe@example.com",
+                            "name": "Jane Doe"
+                        }
+                    ],
+                    "custom_args": {
+                        "New Argument 1": "New Value 1",
+                        "activationAttempt": "1",
+                        "customerAccountNumber":
+                            "[CUSTOMER ACCOUNT NUMBER GOES HERE]"
+                    },
+                    "headers": {
+                        "X-Accept-Language": "en",
+                        "X-Mailer": "MyApp"
+                    },
+                    "send_at": 1409348513,
+                    "subject": "Hello, World!",
+                    "substitutions": {
+                        "id": "substitutions",
+                        "type": "object"
+                    },
+                    "to": [
+                        {
+                            "email": "john.doe@example.com",
+                            "name": "John Doe"
+                        }
+                    ]
+                }
+            ],
+            "reply_to": {
+                "email": "sam.smith@example.com",
+                "name": "Sam Smith"
+            },
+            "sections": {
+                "section": {
+                    ":sectionName1": "section 1 text",
+                    ":sectionName2": "section 2 text"
+                }
+            },
+            "send_at": 1409348513,
+            "subject": "Hello, World!",
+            "template_id": "[YOUR TEMPLATE ID GOES HERE]",
+            "tracking_settings": {
+                "click_tracking": {
+                    "enable": True,
+                    "enable_text": True
+                },
+                "ganalytics": {
+                    "enable": True,
+                    "utm_campaign": "[NAME OF YOUR REFERRER SOURCE]",
+                    "utm_content": "[USE THIS SPACE TO DIFFERENTIATE "
+                                   "YOUR EMAIL FROM ADS]",
+                    "utm_medium": "[NAME OF YOUR MARKETING MEDIUM e.g. email]",
+                    "utm_name": "[NAME OF YOUR CAMPAIGN]",
+                    "utm_term": "[IDENTIFY PAID KEYWORDS HERE]"
+                },
+                "open_tracking": {
+                    "enable": True,
+                    "substitution_tag": "%opentrack"
+                },
+                "subscription_tracking": {
+                    "enable": True,
+                    "html": "If you would like to unsubscribe and stop "
+                            "receiving these emails <% clickhere %>.",
+                    "substitution_tag": "<%click here%>",
+                    "text": "If you would like to unsubscribe and stop "
+                            "receiveing these emails <% click here %>."
+                }
+            }
         }
-      ],
-      "cc": [
-        {
-          "email": "jane.doe@example.com",
-          "name": "Jane Doe"
-        }
-      ],
-      "custom_args": {
-        "New Argument 1": "New Value 1",
-        "activationAttempt": "1",
-        "customerAccountNumber": "[CUSTOMER ACCOUNT NUMBER GOES HERE]"
-      },
-      "headers": {
-        "X-Accept-Language": "en",
-        "X-Mailer": "MyApp"
-      },
-      "send_at": 1409348513,
-      "subject": "Hello, World!",
-      "substitutions": {
-        "id": "substitutions",
-        "type": "object"
-      },
-      "to": [
-        {
-          "email": "john.doe@example.com",
-          "name": "John Doe"
-        }
-      ]
-    }
-  ],
-  "reply_to": {
-    "email": "sam.smith@example.com",
-    "name": "Sam Smith"
-  },
-  "sections": {
-    "section": {
-      ":sectionName1": "section 1 text",
-      ":sectionName2": "section 2 text"
-    }
-  },
-  "send_at": 1409348513,
-  "subject": "Hello, World!",
-  "template_id": "[YOUR TEMPLATE ID GOES HERE]",
-  "tracking_settings": {
-    "click_tracking": {
-      "enable": True,
-      "enable_text": True
-    },
-    "ganalytics": {
-      "enable": True,
-      "utm_campaign": "[NAME OF YOUR REFERRER SOURCE]",
-      "utm_content": "[USE THIS SPACE TO DIFFERENTIATE YOUR EMAIL FROM ADS]",
-      "utm_medium": "[NAME OF YOUR MARKETING MEDIUM e.g. email]",
-      "utm_name": "[NAME OF YOUR CAMPAIGN]",
-      "utm_term": "[IDENTIFY PAID KEYWORDS HERE]"
-    },
-    "open_tracking": {
-      "enable": True,
-      "substitution_tag": "%opentrack"
-    },
-    "subscription_tracking": {
-      "enable": True,
-      "html": "If you would like to unsubscribe and stop receiving these emails <% clickhere %>.",
-      "substitution_tag": "<%click here%>",
-      "text": "If you would like to unsubscribe and stop receiveing these emails <% click here %>."
-    }
-  }
-}
         headers = {'X-Mock': 202}
-        response = self.sg.client.mail.send.post(request_body=data, request_headers=headers)
+        response = self.sg.client.mail.send.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 202)
 
     def test_mail_settings_get(self):
         params = {'limit': 1, 'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.get(query_params=params, request_headers=headers)
+        response = self.sg.client.mail_settings.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_address_whitelist_patch(self):
         data = {
-  "enabled": True,
-  "list": [
-    "email1@example.com",
-    "example.com"
-  ]
-}
+            "enabled": True,
+            "list": [
+                "email1@example.com",
+                "example.com"
+            ]
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.address_whitelist.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.mail_settings.address_whitelist.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_address_whitelist_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.address_whitelist.get(request_headers=headers)
+        response = self.sg.client.mail_settings.address_whitelist.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_bcc_patch(self):
         data = {
-  "email": "email@example.com",
-  "enabled": False
-}
+            "email": "email@example.com",
+            "enabled": False
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.bcc.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.mail_settings.bcc.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_bcc_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.bcc.get(request_headers=headers)
+        response = self.sg.client.mail_settings.bcc.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_bounce_purge_patch(self):
         data = {
-  "enabled": True,
-  "hard_bounces": 5,
-  "soft_bounces": 5
-}
+            "enabled": True,
+            "hard_bounces": 5,
+            "soft_bounces": 5
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.bounce_purge.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.mail_settings.bounce_purge.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_bounce_purge_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.bounce_purge.get(request_headers=headers)
+        response = self.sg.client.mail_settings.bounce_purge.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_footer_patch(self):
         data = {
-  "enabled": True,
-  "html_content": "...",
-  "plain_content": "..."
-}
+            "enabled": True,
+            "html_content": "...",
+            "plain_content": "..."
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.footer.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.mail_settings.footer.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_footer_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.footer.get(request_headers=headers)
+        response = self.sg.client.mail_settings.footer.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_forward_bounce_patch(self):
         data = {
-  "email": "example@example.com",
-  "enabled": True
-}
+            "email": "example@example.com",
+            "enabled": True
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.forward_bounce.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.mail_settings.forward_bounce.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_forward_bounce_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.forward_bounce.get(request_headers=headers)
+        response = self.sg.client.mail_settings.forward_bounce.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_forward_spam_patch(self):
         data = {
-  "email": "",
-  "enabled": False
-}
+            "email": "",
+            "enabled": False
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.forward_spam.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.mail_settings.forward_spam.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_forward_spam_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.forward_spam.get(request_headers=headers)
+        response = self.sg.client.mail_settings.forward_spam.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_plain_content_patch(self):
         data = {
-  "enabled": False
-}
+            "enabled": False
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.plain_content.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.mail_settings.plain_content.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_plain_content_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.plain_content.get(request_headers=headers)
+        response = self.sg.client.mail_settings.plain_content.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_spam_check_patch(self):
         data = {
-  "enabled": True,
-  "max_score": 5,
-  "url": "url"
-}
+            "enabled": True,
+            "max_score": 5,
+            "url": "url"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.spam_check.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.mail_settings.spam_check.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_spam_check_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.spam_check.get(request_headers=headers)
+        response = self.sg.client.mail_settings.spam_check.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_template_patch(self):
         data = {
-  "enabled": True,
-  "html_content": "<% body %>"
-}
+            "enabled": True,
+            "html_content": "<% body %>"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.template.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.mail_settings.template.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mail_settings_template_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.mail_settings.template.get(request_headers=headers)
+        response = self.sg.client.mail_settings.template.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_mailbox_providers_stats_get(self):
-        params = {'end_date': '2016-04-01', 'mailbox_providers': 'test_string', 'aggregated_by': 'day', 'limit': 1, 'offset': 1, 'start_date': '2016-01-01'}
+        params = {
+            'end_date': '2016-04-01',
+            'mailbox_providers': 'test_string',
+            'aggregated_by': 'day',
+            'limit': 1,
+            'offset': 1,
+            'start_date': '2016-01-01'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.mailbox_providers.stats.get(query_params=params, request_headers=headers)
+        response = self.sg.client.mailbox_providers.stats.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_partner_settings_get(self):
         params = {'limit': 1, 'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.partner_settings.get(query_params=params, request_headers=headers)
+        response = self.sg.client.partner_settings.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_partner_settings_new_relic_patch(self):
         data = {
-  "enable_subuser_statistics": True,
-  "enabled": True,
-  "license_key": ""
-}
+            "enable_subuser_statistics": True,
+            "enabled": True,
+            "license_key": ""
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.partner_settings.new_relic.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.partner_settings.new_relic.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_partner_settings_new_relic_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.partner_settings.new_relic.get(request_headers=headers)
+        response = self.sg.client.partner_settings.new_relic.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_scopes_get(self):
@@ -1138,24 +1308,25 @@ class UnitTests(unittest.TestCase):
 
     def test_senders_post(self):
         data = {
-  "address": "123 Elm St.",
-  "address_2": "Apt. 456",
-  "city": "Denver",
-  "country": "United States",
-  "from": {
-    "email": "from@example.com",
-    "name": "Example INC"
-  },
-  "nickname": "My Sender ID",
-  "reply_to": {
-    "email": "replyto@example.com",
-    "name": "Example INC"
-  },
-  "state": "Colorado",
-  "zip": "80202"
-}
+            "address": "123 Elm St.",
+            "address_2": "Apt. 456",
+            "city": "Denver",
+            "country": "United States",
+            "from": {
+                "email": "from@example.com",
+                "name": "Example INC"
+            },
+            "nickname": "My Sender ID",
+            "reply_to": {
+                "email": "replyto@example.com",
+                "name": "Example INC"
+            },
+            "state": "Colorado",
+            "zip": "80202"
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.senders.post(request_body=data, request_headers=headers)
+        response = self.sg.client.senders.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_senders_get(self):
@@ -1165,291 +1336,357 @@ class UnitTests(unittest.TestCase):
 
     def test_senders__sender_id__patch(self):
         data = {
-  "address": "123 Elm St.",
-  "address_2": "Apt. 456",
-  "city": "Denver",
-  "country": "United States",
-  "from": {
-    "email": "from@example.com",
-    "name": "Example INC"
-  },
-  "nickname": "My Sender ID",
-  "reply_to": {
-    "email": "replyto@example.com",
-    "name": "Example INC"
-  },
-  "state": "Colorado",
-  "zip": "80202"
-}
+            "address": "123 Elm St.",
+            "address_2": "Apt. 456",
+            "city": "Denver",
+            "country": "United States",
+            "from": {
+                "email": "from@example.com",
+                "name": "Example INC"
+            },
+            "nickname": "My Sender ID",
+            "reply_to": {
+                "email": "replyto@example.com",
+                "name": "Example INC"
+            },
+            "state": "Colorado",
+            "zip": "80202"
+        }
         sender_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.senders._(sender_id).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.senders._(sender_id).patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_senders__sender_id__get(self):
         sender_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.senders._(sender_id).get(request_headers=headers)
+        response = self.sg.client.senders._(
+            sender_id).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_senders__sender_id__delete(self):
         sender_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.senders._(sender_id).delete(request_headers=headers)
+        response = self.sg.client.senders._(
+            sender_id).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_senders__sender_id__resend_verification_post(self):
         sender_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.senders._(sender_id).resend_verification.post(request_headers=headers)
+        response = self.sg.client.senders._(
+            sender_id).resend_verification.post(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_stats_get(self):
-        params = {'aggregated_by': 'day', 'limit': 1, 'start_date': '2016-01-01', 'end_date': '2016-04-01', 'offset': 1}
+        params = {
+            'aggregated_by': 'day',
+            'limit': 1,
+            'start_date': '2016-01-01',
+            'end_date': '2016-04-01',
+            'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.stats.get(query_params=params, request_headers=headers)
+        response = self.sg.client.stats.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_subusers_post(self):
         data = {
-  "email": "John@example.com",
-  "ips": [
-    "1.1.1.1",
-    "2.2.2.2"
-  ],
-  "password": "johns_password",
-  "username": "John@example.com"
-}
+            "email": "John@example.com",
+            "ips": [
+                "1.1.1.1",
+                "2.2.2.2"
+            ],
+            "password": "johns_password",
+            "username": "John@example.com"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.subusers.post(request_body=data, request_headers=headers)
+        response = self.sg.client.subusers.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_subusers_get(self):
         params = {'username': 'test_string', 'limit': 1, 'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.subusers.get(query_params=params, request_headers=headers)
+        response = self.sg.client.subusers.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_subusers_reputations_get(self):
         params = {'usernames': 'test_string'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.subusers.reputations.get(query_params=params, request_headers=headers)
+        response = self.sg.client.subusers.reputations.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_subusers_stats_get(self):
-        params = {'end_date': '2016-04-01', 'aggregated_by': 'day', 'limit': 1, 'offset': 1, 'start_date': '2016-01-01', 'subusers': 'test_string'}
+        params = {
+            'end_date': '2016-04-01',
+            'aggregated_by': 'day',
+            'limit': 1,
+            'offset': 1,
+            'start_date': '2016-01-01',
+            'subusers': 'test_string'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.subusers.stats.get(query_params=params, request_headers=headers)
+        response = self.sg.client.subusers.stats.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_subusers_stats_monthly_get(self):
-        params = {'subuser': 'test_string', 'limit': 1, 'sort_by_metric': 'test_string', 'offset': 1, 'date': 'test_string', 'sort_by_direction': 'asc'}
+        params = {
+            'subuser': 'test_string',
+            'limit': 1,
+            'sort_by_metric': 'test_string',
+            'offset': 1,
+            'date': 'test_string',
+            'sort_by_direction': 'asc'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.subusers.stats.monthly.get(query_params=params, request_headers=headers)
+        response = self.sg.client.subusers.stats.monthly.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_subusers_stats_sums_get(self):
-        params = {'end_date': '2016-04-01', 'aggregated_by': 'day', 'limit': 1, 'sort_by_metric': 'test_string', 'offset': 1, 'start_date': '2016-01-01', 'sort_by_direction': 'asc'}
+        params = {
+            'end_date': '2016-04-01',
+            'aggregated_by': 'day',
+            'limit': 1,
+            'sort_by_metric': 'test_string',
+            'offset': 1,
+            'start_date': '2016-01-01',
+            'sort_by_direction': 'asc'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.subusers.stats.sums.get(query_params=params, request_headers=headers)
+        response = self.sg.client.subusers.stats.sums.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_subusers__subuser_name__patch(self):
         data = {
-  "disabled": False
-}
+            "disabled": False
+        }
         subuser_name = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.subusers._(subuser_name).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.subusers._(subuser_name).patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_subusers__subuser_name__delete(self):
         subuser_name = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.subusers._(subuser_name).delete(request_headers=headers)
+        response = self.sg.client.subusers._(
+            subuser_name).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_subusers__subuser_name__ips_put(self):
         data = [
-  "127.0.0.1"
-]
+            "127.0.0.1"
+        ]
         subuser_name = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.subusers._(subuser_name).ips.put(request_body=data, request_headers=headers)
+        response = self.sg.client.subusers._(subuser_name).ips.put(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_subusers__subuser_name__monitor_put(self):
         data = {
-  "email": "example@example.com",
-  "frequency": 500
-}
+            "email": "example@example.com",
+            "frequency": 500
+        }
         subuser_name = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.subusers._(subuser_name).monitor.put(request_body=data, request_headers=headers)
+        response = self.sg.client.subusers._(subuser_name).monitor.put(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_subusers__subuser_name__monitor_post(self):
         data = {
-  "email": "example@example.com",
-  "frequency": 50000
-}
+            "email": "example@example.com",
+            "frequency": 50000
+        }
         subuser_name = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.subusers._(subuser_name).monitor.post(request_body=data, request_headers=headers)
+        response = self.sg.client.subusers._(subuser_name).monitor.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_subusers__subuser_name__monitor_get(self):
         subuser_name = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.subusers._(subuser_name).monitor.get(request_headers=headers)
+        response = self.sg.client.subusers._(
+            subuser_name).monitor.get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_subusers__subuser_name__monitor_delete(self):
         subuser_name = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.subusers._(subuser_name).monitor.delete(request_headers=headers)
+        response = self.sg.client.subusers._(
+            subuser_name).monitor.delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_subusers__subuser_name__stats_monthly_get(self):
-        params = {'date': 'test_string', 'sort_by_direction': 'asc', 'limit': 1, 'sort_by_metric': 'test_string', 'offset': 1}
+        params = {
+            'date': 'test_string',
+            'sort_by_direction': 'asc',
+            'limit': 1,
+            'sort_by_metric': 'test_string',
+            'offset': 1}
         subuser_name = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.subusers._(subuser_name).stats.monthly.get(query_params=params, request_headers=headers)
+        response = self.sg.client.subusers._(subuser_name).stats.monthly.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_suppression_blocks_get(self):
         params = {'start_time': 1, 'limit': 1, 'end_time': 1, 'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.suppression.blocks.get(query_params=params, request_headers=headers)
+        response = self.sg.client.suppression.blocks.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_suppression_blocks_delete(self):
         data = {
-  "delete_all": False,
-  "emails": [
-    "example1@example.com",
-    "example2@example.com"
-  ]
-}
+            "delete_all": False,
+            "emails": [
+                "example1@example.com",
+                "example2@example.com"
+            ]
+        }
         headers = {'X-Mock': 204}
-        response = self.sg.client.suppression.blocks.delete(request_body=data, request_headers=headers)
+        response = self.sg.client.suppression.blocks.delete(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_suppression_blocks__email__get(self):
         email = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.suppression.blocks._(email).get(request_headers=headers)
+        response = self.sg.client.suppression.blocks._(
+            email).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_suppression_blocks__email__delete(self):
         email = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.suppression.blocks._(email).delete(request_headers=headers)
+        response = self.sg.client.suppression.blocks._(
+            email).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_suppression_bounces_get(self):
         params = {'start_time': 1, 'end_time': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.suppression.bounces.get(query_params=params, request_headers=headers)
+        response = self.sg.client.suppression.bounces.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_suppression_bounces_delete(self):
         data = {
-  "delete_all": True,
-  "emails": [
-    "example@example.com",
-    "example2@example.com"
-  ]
-}
+            "delete_all": True,
+            "emails": [
+                "example@example.com",
+                "example2@example.com"
+            ]
+        }
         headers = {'X-Mock': 204}
-        response = self.sg.client.suppression.bounces.delete(request_body=data, request_headers=headers)
+        response = self.sg.client.suppression.bounces.delete(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_suppression_bounces__email__get(self):
         email = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.suppression.bounces._(email).get(request_headers=headers)
+        response = self.sg.client.suppression.bounces._(
+            email).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_suppression_bounces__email__delete(self):
         params = {'email_address': 'example@example.com'}
         email = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.suppression.bounces._(email).delete(query_params=params, request_headers=headers)
+        response = self.sg.client.suppression.bounces._(email).delete(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_suppression_invalid_emails_get(self):
         params = {'start_time': 1, 'limit': 1, 'end_time': 1, 'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.suppression.invalid_emails.get(query_params=params, request_headers=headers)
+        response = self.sg.client.suppression.invalid_emails.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_suppression_invalid_emails_delete(self):
         data = {
-  "delete_all": False,
-  "emails": [
-    "example1@example.com",
-    "example2@example.com"
-  ]
-}
+            "delete_all": False,
+            "emails": [
+                "example1@example.com",
+                "example2@example.com"
+            ]
+        }
         headers = {'X-Mock': 204}
-        response = self.sg.client.suppression.invalid_emails.delete(request_body=data, request_headers=headers)
+        response = self.sg.client.suppression.invalid_emails.delete(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_suppression_invalid_emails__email__get(self):
         email = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.suppression.invalid_emails._(email).get(request_headers=headers)
+        response = self.sg.client.suppression.invalid_emails._(
+            email).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_suppression_invalid_emails__email__delete(self):
         email = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.suppression.invalid_emails._(email).delete(request_headers=headers)
+        response = self.sg.client.suppression.invalid_emails._(
+            email).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_suppression_spam_report__email__get(self):
         email = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.suppression.spam_report._(email).get(request_headers=headers)
+        response = self.sg.client.suppression.spam_report._(
+            email).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_suppression_spam_report__email__delete(self):
         email = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.suppression.spam_report._(email).delete(request_headers=headers)
+        response = self.sg.client.suppression.spam_report._(
+            email).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_suppression_spam_reports_get(self):
         params = {'start_time': 1, 'limit': 1, 'end_time': 1, 'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.suppression.spam_reports.get(query_params=params, request_headers=headers)
+        response = self.sg.client.suppression.spam_reports.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_suppression_spam_reports_delete(self):
         data = {
-  "delete_all": False,
-  "emails": [
-    "example1@example.com",
-    "example2@example.com"
-  ]
-}
+            "delete_all": False,
+            "emails": [
+                "example1@example.com",
+                "example2@example.com"
+            ]
+        }
         headers = {'X-Mock': 204}
-        response = self.sg.client.suppression.spam_reports.delete(request_body=data, request_headers=headers)
+        response = self.sg.client.suppression.spam_reports.delete(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_suppression_unsubscribes_get(self):
         params = {'start_time': 1, 'limit': 1, 'end_time': 1, 'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.suppression.unsubscribes.get(query_params=params, request_headers=headers)
+        response = self.sg.client.suppression.unsubscribes.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_templates_post(self):
         data = {
-  "name": "example_name"
-}
+            "name": "example_name"
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.templates.post(request_body=data, request_headers=headers)
+        response = self.sg.client.templates.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_templates_get(self):
@@ -1459,140 +1696,157 @@ class UnitTests(unittest.TestCase):
 
     def test_templates__template_id__patch(self):
         data = {
-  "name": "new_example_name"
-}
+            "name": "new_example_name"
+        }
         template_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.templates._(template_id).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.templates._(template_id).patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_templates__template_id__get(self):
         template_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.templates._(template_id).get(request_headers=headers)
+        response = self.sg.client.templates._(
+            template_id).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_templates__template_id__delete(self):
         template_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.templates._(template_id).delete(request_headers=headers)
+        response = self.sg.client.templates._(
+            template_id).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_templates__template_id__versions_post(self):
         data = {
-  "active": 1,
-  "html_content": "<%body%>",
-  "name": "example_version_name",
-  "plain_content": "<%body%>",
-  "subject": "<%subject%>",
-  "template_id": "ddb96bbc-9b92-425e-8979-99464621b543"
-}
+            "active": 1,
+            "html_content": "<%body%>",
+            "name": "example_version_name",
+            "plain_content": "<%body%>",
+            "subject": "<%subject%>",
+            "template_id": "ddb96bbc-9b92-425e-8979-99464621b543"
+        }
         template_id = "test_url_param"
         headers = {'X-Mock': 201}
-        response = self.sg.client.templates._(template_id).versions.post(request_body=data, request_headers=headers)
+        response = self.sg.client.templates._(template_id).versions.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_templates__template_id__versions__version_id__patch(self):
         data = {
-  "active": 1,
-  "html_content": "<%body%>",
-  "name": "updated_example_name",
-  "plain_content": "<%body%>",
-  "subject": "<%subject%>"
-}
+            "active": 1,
+            "html_content": "<%body%>",
+            "name": "updated_example_name",
+            "plain_content": "<%body%>",
+            "subject": "<%subject%>"
+        }
         template_id = "test_url_param"
         version_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.templates._(template_id).versions._(version_id).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.templates._(template_id).versions._(
+            version_id).patch(request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_templates__template_id__versions__version_id__get(self):
         template_id = "test_url_param"
         version_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.templates._(template_id).versions._(version_id).get(request_headers=headers)
+        response = self.sg.client.templates._(template_id).versions._(
+            version_id).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_templates__template_id__versions__version_id__delete(self):
         template_id = "test_url_param"
         version_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.templates._(template_id).versions._(version_id).delete(request_headers=headers)
+        response = self.sg.client.templates._(template_id).versions._(
+            version_id).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_templates__template_id__versions__version_id__activate_post(self):
         template_id = "test_url_param"
         version_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.templates._(template_id).versions._(version_id).activate.post(request_headers=headers)
+        response = self.sg.client.templates._(template_id).versions._(
+            version_id).activate.post(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_tracking_settings_get(self):
         params = {'limit': 1, 'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.tracking_settings.get(query_params=params, request_headers=headers)
+        response = self.sg.client.tracking_settings.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_tracking_settings_click_patch(self):
         data = {
-  "enabled": True
-}
+            "enabled": True
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.tracking_settings.click.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.tracking_settings.click.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_tracking_settings_click_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.tracking_settings.click.get(request_headers=headers)
+        response = self.sg.client.tracking_settings.click.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_tracking_settings_google_analytics_patch(self):
         data = {
-  "enabled": True,
-  "utm_campaign": "website",
-  "utm_content": "",
-  "utm_medium": "email",
-  "utm_source": "sendgrid.com",
-  "utm_term": ""
-}
+            "enabled": True,
+            "utm_campaign": "website",
+            "utm_content": "",
+            "utm_medium": "email",
+            "utm_source": "sendgrid.com",
+            "utm_term": ""
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.tracking_settings.google_analytics.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.tracking_settings.google_analytics.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_tracking_settings_google_analytics_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.tracking_settings.google_analytics.get(request_headers=headers)
+        response = self.sg.client.tracking_settings.google_analytics.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_tracking_settings_open_patch(self):
         data = {
-  "enabled": True
-}
+            "enabled": True
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.tracking_settings.open.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.tracking_settings.open.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_tracking_settings_open_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.tracking_settings.open.get(request_headers=headers)
+        response = self.sg.client.tracking_settings.open.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_tracking_settings_subscription_patch(self):
         data = {
-  "enabled": True,
-  "html_content": "html content",
-  "landing": "landing page html",
-  "plain_content": "text content",
-  "replace": "replacement tag",
-  "url": "url"
-}
+            "enabled": True,
+            "html_content": "html content",
+            "landing": "landing page html",
+            "plain_content": "text content",
+            "replace": "replacement tag",
+            "url": "url"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.tracking_settings.subscription.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.tracking_settings.subscription.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_tracking_settings_subscription_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.tracking_settings.subscription.get(request_headers=headers)
+        response = self.sg.client.tracking_settings.subscription.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_account_get(self):
@@ -1607,10 +1861,11 @@ class UnitTests(unittest.TestCase):
 
     def test_user_email_put(self):
         data = {
-  "email": "example@example.com"
-}
+            "email": "example@example.com"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.email.put(request_body=data, request_headers=headers)
+        response = self.sg.client.user.email.put(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_email_get(self):
@@ -1620,21 +1875,23 @@ class UnitTests(unittest.TestCase):
 
     def test_user_password_put(self):
         data = {
-  "new_password": "new_password",
-  "old_password": "old_password"
-}
+            "new_password": "new_password",
+            "old_password": "old_password"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.password.put(request_body=data, request_headers=headers)
+        response = self.sg.client.user.password.put(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_profile_patch(self):
         data = {
-  "city": "Orange",
-  "first_name": "Example",
-  "last_name": "User"
-}
+            "city": "Orange",
+            "first_name": "Example",
+            "last_name": "User"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.profile.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.user.profile.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_profile_get(self):
@@ -1644,59 +1901,67 @@ class UnitTests(unittest.TestCase):
 
     def test_user_scheduled_sends_post(self):
         data = {
-  "batch_id": "YOUR_BATCH_ID",
-  "status": "pause"
-}
+            "batch_id": "YOUR_BATCH_ID",
+            "status": "pause"
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.user.scheduled_sends.post(request_body=data, request_headers=headers)
+        response = self.sg.client.user.scheduled_sends.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_user_scheduled_sends_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.scheduled_sends.get(request_headers=headers)
+        response = self.sg.client.user.scheduled_sends.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_scheduled_sends__batch_id__patch(self):
         data = {
-  "status": "pause"
-}
+            "status": "pause"
+        }
         batch_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.user.scheduled_sends._(batch_id).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.user.scheduled_sends._(
+            batch_id).patch(request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_user_scheduled_sends__batch_id__get(self):
         batch_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.scheduled_sends._(batch_id).get(request_headers=headers)
+        response = self.sg.client.user.scheduled_sends._(
+            batch_id).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_scheduled_sends__batch_id__delete(self):
         batch_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.user.scheduled_sends._(batch_id).delete(request_headers=headers)
+        response = self.sg.client.user.scheduled_sends._(
+            batch_id).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_user_settings_enforced_tls_patch(self):
         data = {
-  "require_tls": True,
-  "require_valid_cert": False
-}
+            "require_tls": True,
+            "require_valid_cert": False
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.settings.enforced_tls.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.user.settings.enforced_tls.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_settings_enforced_tls_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.settings.enforced_tls.get(request_headers=headers)
+        response = self.sg.client.user.settings.enforced_tls.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_username_put(self):
         data = {
-  "username": "test_username"
-}
+            "username": "test_username"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.username.put(request_body=data, request_headers=headers)
+        response = self.sg.client.user.username.put(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_username_get(self):
@@ -1706,276 +1971,322 @@ class UnitTests(unittest.TestCase):
 
     def test_user_webhooks_event_settings_patch(self):
         data = {
-  "bounce": True,
-  "click": True,
-  "deferred": True,
-  "delivered": True,
-  "dropped": True,
-  "enabled": True,
-  "group_resubscribe": True,
-  "group_unsubscribe": True,
-  "open": True,
-  "processed": True,
-  "spam_report": True,
-  "unsubscribe": True,
-  "url": "url"
-}
+            "bounce": True,
+            "click": True,
+            "deferred": True,
+            "delivered": True,
+            "dropped": True,
+            "enabled": True,
+            "group_resubscribe": True,
+            "group_unsubscribe": True,
+            "open": True,
+            "processed": True,
+            "spam_report": True,
+            "unsubscribe": True,
+            "url": "url"
+        }
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.webhooks.event.settings.patch(request_body=data, request_headers=headers)
+        response = self.sg.client.user.webhooks.event.settings.patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_webhooks_event_settings_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.webhooks.event.settings.get(request_headers=headers)
+        response = self.sg.client.user.webhooks.event.settings.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_webhooks_event_test_post(self):
         data = {
-  "url": "url"
-}
+            "url": "url"
+        }
         headers = {'X-Mock': 204}
-        response = self.sg.client.user.webhooks.event.test.post(request_body=data, request_headers=headers)
+        response = self.sg.client.user.webhooks.event.test.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_user_webhooks_parse_settings_post(self):
         data = {
-  "hostname": "myhostname.com",
-  "send_raw": False,
-  "spam_check": True,
-  "url": "http://email.myhosthame.com"
-}
+            "hostname": "myhostname.com",
+            "send_raw": False,
+            "spam_check": True,
+            "url": "http://email.myhosthame.com"
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.user.webhooks.parse.settings.post(request_body=data, request_headers=headers)
+        response = self.sg.client.user.webhooks.parse.settings.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_user_webhooks_parse_settings_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.webhooks.parse.settings.get(request_headers=headers)
+        response = self.sg.client.user.webhooks.parse.settings.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_webhooks_parse_settings__hostname__patch(self):
         data = {
-  "send_raw": True,
-  "spam_check": False,
-  "url": "http://newdomain.com/parse"
-}
+            "send_raw": True,
+            "spam_check": False,
+            "url": "http://newdomain.com/parse"
+        }
         hostname = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.webhooks.parse.settings._(hostname).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.user.webhooks.parse.settings._(
+            hostname).patch(request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_webhooks_parse_settings__hostname__get(self):
         hostname = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.webhooks.parse.settings._(hostname).get(request_headers=headers)
+        response = self.sg.client.user.webhooks.parse.settings._(
+            hostname).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_user_webhooks_parse_settings__hostname__delete(self):
         hostname = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.user.webhooks.parse.settings._(hostname).delete(request_headers=headers)
+        response = self.sg.client.user.webhooks.parse.settings._(
+            hostname).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_user_webhooks_parse_stats_get(self):
-        params = {'aggregated_by': 'day', 'limit': 'test_string', 'start_date': '2016-01-01', 'end_date': '2016-04-01', 'offset': 'test_string'}
+        params = {
+            'aggregated_by': 'day',
+            'limit': 'test_string',
+            'start_date': '2016-01-01',
+            'end_date': '2016-04-01',
+            'offset': 'test_string'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.webhooks.parse.stats.get(query_params=params, request_headers=headers)
+        response = self.sg.client.user.webhooks.parse.stats.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_domains_post(self):
         data = {
-  "automatic_security": False,
-  "custom_spf": True,
-  "default": True,
-  "domain": "example.com",
-  "ips": [
-    "192.168.1.1",
-    "192.168.1.2"
-  ],
-  "subdomain": "news",
-  "username": "john@example.com"
-}
+            "automatic_security": False,
+            "custom_spf": True,
+            "default": True,
+            "domain": "example.com",
+            "ips": [
+                "192.168.1.1",
+                "192.168.1.2"
+            ],
+            "subdomain": "news",
+            "username": "john@example.com"
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.whitelabel.domains.post(request_body=data, request_headers=headers)
+        response = self.sg.client.whitelabel.domains.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_whitelabel_domains_get(self):
-        params = {'username': 'test_string', 'domain': 'test_string', 'exclude_subusers': 'true', 'limit': 1, 'offset': 1}
+        params = {
+            'username': 'test_string',
+            'domain': 'test_string',
+            'exclude_subusers': 'true',
+            'limit': 1,
+            'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.domains.get(query_params=params, request_headers=headers)
+        response = self.sg.client.whitelabel.domains.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_domains_default_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.domains.default.get(request_headers=headers)
+        response = self.sg.client.whitelabel.domains.default.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_domains_subuser_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.domains.subuser.get(request_headers=headers)
+        response = self.sg.client.whitelabel.domains.subuser.get(
+            request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_domains_subuser_delete(self):
         headers = {'X-Mock': 204}
-        response = self.sg.client.whitelabel.domains.subuser.delete(request_headers=headers)
+        response = self.sg.client.whitelabel.domains.subuser.delete(
+            request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_whitelabel_domains__domain_id__patch(self):
         data = {
-  "custom_spf": True,
-  "default": False
-}
+            "custom_spf": True,
+            "default": False
+        }
         domain_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.domains._(domain_id).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.whitelabel.domains._(
+            domain_id).patch(request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_domains__domain_id__get(self):
         domain_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.domains._(domain_id).get(request_headers=headers)
+        response = self.sg.client.whitelabel.domains._(
+            domain_id).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_domains__domain_id__delete(self):
         domain_id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.whitelabel.domains._(domain_id).delete(request_headers=headers)
+        response = self.sg.client.whitelabel.domains._(
+            domain_id).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_whitelabel_domains__domain_id__subuser_post(self):
         data = {
-  "username": "jane@example.com"
-}
+            "username": "jane@example.com"
+        }
         domain_id = "test_url_param"
         headers = {'X-Mock': 201}
-        response = self.sg.client.whitelabel.domains._(domain_id).subuser.post(request_body=data, request_headers=headers)
+        response = self.sg.client.whitelabel.domains._(
+            domain_id).subuser.post(request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_whitelabel_domains__id__ips_post(self):
         data = {
-  "ip": "192.168.0.1"
-}
+            "ip": "192.168.0.1"
+        }
         id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.domains._(id).ips.post(request_body=data, request_headers=headers)
+        response = self.sg.client.whitelabel.domains._(
+            id).ips.post(request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_domains__id__ips__ip__delete(self):
         id = "test_url_param"
         ip = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.domains._(id).ips._(ip).delete(request_headers=headers)
+        response = self.sg.client.whitelabel.domains._(
+            id).ips._(ip).delete(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_domains__id__validate_post(self):
         id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.domains._(id).validate.post(request_headers=headers)
+        response = self.sg.client.whitelabel.domains._(
+            id).validate.post(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_ips_post(self):
         data = {
-  "domain": "example.com",
-  "ip": "192.168.1.1",
-  "subdomain": "email"
-}
+            "domain": "example.com",
+            "ip": "192.168.1.1",
+            "subdomain": "email"
+        }
         headers = {'X-Mock': 201}
-        response = self.sg.client.whitelabel.ips.post(request_body=data, request_headers=headers)
+        response = self.sg.client.whitelabel.ips.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_whitelabel_ips_get(self):
         params = {'ip': 'test_string', 'limit': 1, 'offset': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.ips.get(query_params=params, request_headers=headers)
+        response = self.sg.client.whitelabel.ips.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_ips__id__get(self):
         id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.ips._(id).get(request_headers=headers)
+        response = self.sg.client.whitelabel.ips._(
+            id).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_ips__id__delete(self):
         id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.whitelabel.ips._(id).delete(request_headers=headers)
+        response = self.sg.client.whitelabel.ips._(
+            id).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_whitelabel_ips__id__validate_post(self):
         id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.ips._(id).validate.post(request_headers=headers)
+        response = self.sg.client.whitelabel.ips._(
+            id).validate.post(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_links_post(self):
         data = {
-  "default": True,
-  "domain": "example.com",
-  "subdomain": "mail"
-}
+            "default": True,
+            "domain": "example.com",
+            "subdomain": "mail"
+        }
         params = {'limit': 1, 'offset': 1}
         headers = {'X-Mock': 201}
-        response = self.sg.client.whitelabel.links.post(request_body=data, query_params=params, request_headers=headers)
+        response = self.sg.client.whitelabel.links.post(
+            request_body=data, query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 201)
 
     def test_whitelabel_links_get(self):
         params = {'limit': 1}
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.links.get(query_params=params, request_headers=headers)
+        response = self.sg.client.whitelabel.links.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_links_default_get(self):
         params = {'domain': 'test_string'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.links.default.get(query_params=params, request_headers=headers)
+        response = self.sg.client.whitelabel.links.default.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_links_subuser_get(self):
         params = {'username': 'test_string'}
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.links.subuser.get(query_params=params, request_headers=headers)
+        response = self.sg.client.whitelabel.links.subuser.get(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_links_subuser_delete(self):
         params = {'username': 'test_string'}
         headers = {'X-Mock': 204}
-        response = self.sg.client.whitelabel.links.subuser.delete(query_params=params, request_headers=headers)
+        response = self.sg.client.whitelabel.links.subuser.delete(
+            query_params=params, request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_whitelabel_links__id__patch(self):
         data = {
-  "default": True
-}
+            "default": True
+        }
         id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.links._(id).patch(request_body=data, request_headers=headers)
+        response = self.sg.client.whitelabel.links._(id).patch(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_links__id__get(self):
         id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.links._(id).get(request_headers=headers)
+        response = self.sg.client.whitelabel.links._(
+            id).get(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_links__id__delete(self):
         id = "test_url_param"
         headers = {'X-Mock': 204}
-        response = self.sg.client.whitelabel.links._(id).delete(request_headers=headers)
+        response = self.sg.client.whitelabel.links._(
+            id).delete(request_headers=headers)
         self.assertEqual(response.status_code, 204)
 
     def test_whitelabel_links__id__validate_post(self):
         id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.links._(id).validate.post(request_headers=headers)
+        response = self.sg.client.whitelabel.links._(
+            id).validate.post(request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     def test_whitelabel_links__link_id__subuser_post(self):
         data = {
-  "username": "jane@example.com"
-}
+            "username": "jane@example.com"
+        }
         link_id = "test_url_param"
         headers = {'X-Mock': 200}
-        response = self.sg.client.whitelabel.links._(link_id).subuser.post(request_body=data, request_headers=headers)
+        response = self.sg.client.whitelabel.links._(link_id).subuser.post(
+            request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
 
     @classmethod

--- a/test/test_sendgrid.py
+++ b/test/test_sendgrid.py
@@ -1,6 +1,4 @@
 import sendgrid
-import json
-from sendgrid import SendGridAPIClient
 from sendgrid.version import __version__
 try:
     import unittest2 as unittest
@@ -23,20 +21,25 @@ class UnitTests(unittest.TestCase):
             os.path.abspath(
                 os.path.dirname(__file__)), '/..')
         cls.sg = sendgrid.SendGridAPIClient(
-            host=host, path=cls.path, api_key=os.environ.get('SENDGRID_API_KEY'))
-        if os.path.isfile('/usr/local/bin/prism') == False:
+            host=host, path=cls.path,
+            api_key=os.environ.get('SENDGRID_API_KEY'))
+        if os.path.isfile('/usr/local/bin/prism') is False:
             if sys.platform != 'win32':
                 try:
                     p1 = subprocess.Popen(
                         [
                             "curl",
-                            "https://raw.githubusercontent.com/stoplightio/prism/master/install.sh"],
+                            "https://raw.githubusercontent.com/stoplightio/"
+                            "prism/master/install.sh"],
                         stdout=subprocess.PIPE)
-                    p2 = subprocess.Popen(
+                    subprocess.Popen(
                         ["sh"], stdin=p1.stdout, stdout=subprocess.PIPE)
                 except Exception as e:
                     print(
-                        "Error downloading the prism binary, you can try downloading directly here (https://github.com/stoplightio/prism/releases) and place in your /user/local/bin directory",
+                        "Error downloading the prism binary, you can try "
+                        "downloading directly here "
+                        "(https://github.com/stoplightio/prism/releases) "
+                        "and place in your /user/local/bin directory",
                         e.read())
                     sys.exit()
             else:


### PR DESCRIPTION
## Summary
According to [CONTRIBUTING](https://github.com/sendgrid/sendgrid-python/blob/master/CONTRIBUTING.md#style-guidelines--naming-conventions) code should pass all pep8 and flake8 errors

On master branch we can see 
```
(python-sedgrid) ~/sendgrid-python$ flake8 . | wc -l
1201
OR
pep8 . | wc -l
1033
```
The goal of this PR to fix all errors.

## After this PR merged:
```
flake8 test/ | wc -l 
test/test_mail.py:212:80: E501 line too long (3359 > 79 characters)
```

## Checks on `sendgrid/` module:
```
flake8 sendgrid/ wc -l
```

## Unit tests:
```
----------------------------------------------------------------------
Ran 238 tests in 32.903s

OK
```

## Install checking tools:
```
pip install flake8 pep8 isort
```