### PR TITLE
Add 'Sending email with attachment' Use Case

### DIFF
--- a/USE_CASES.md
+++ b/USE_CASES.md
@@ -3,6 +3,7 @@ This documentation provides examples for specific use cases. Please [open an iss
 # Table of Contents
 
 * [Transactional Templates](#transactional_templates)
+* [Attachment](#attachment)
 
 <a name="transactional_templates"></a>
 # Transactional Templates
@@ -117,6 +118,53 @@ try:
 except urllib.HTTPError as e:
     print e.read()
     exit()
+print(response.status_code)
+print(response.body)
+print(response.headers)
+```
+
+<a name="attachment"></a>
+# Attachment
+
+```python
+import base64
+import sendgrid
+import os
+from sendgrid.helpers.mail import Email, Content, Mail, Attachment
+try:
+    # Python 3
+    import urllib.request as urllib
+except ImportError:
+    # Python 2
+    import urllib2 as urllib
+
+sg = sendgrid.SendGridAPIClient(apikey=os.environ.get('SENDGRID_API_KEY'))
+from_email = Email("test@example.com")
+subject = "subject"
+to_email = Email("to_email@example.com")
+content = Content("text/html", "I'm a content example")
+
+file_path = "file_path.pdf"
+with open(file_path,'rb') as f:
+    data = f.read()
+    f.close()
+encoded = base64.b64encode(data).decode()
+
+attachment = Attachment()
+attachment.set_content(encoded)
+attachment.set_type("application/pdf")
+attachment.set_filename("test.pdf")
+attachment.set_disposition("attachment")
+attachment.set_content_id("Example Content ID")
+
+mail = Mail(from_email, subject, to_email, content)
+mail.add_attachment(attachment)
+try:
+    response = sg.client.mail.send.post(request_body=mail.get())
+except urllib.HTTPError as e:
+    print(e.read())
+    exit()
+
 print(response.status_code)
 print(response.body)
 print(response.headers)


### PR DESCRIPTION
Add document for https://github.com/sendgrid/sendgrid-python/issues/270

Need to use `base64.b64encode(data).decode()` because in python3, `b64encode` returns `bytes` instead of `string`

Reference:
https://docs.python.org/2/library/base64.html
https://docs.python.org/3/library/base64.html