### PR TITLE
Exclude test package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     author='Elmer Thomas, Yamil Asusta',
     author_email='dx@sendgrid.com',
     url='https://github.com/sendgrid/sendgrid-python/',
-    packages=find_packages(exclude=["temp*.py", "register.py"]),
+    packages=find_packages(exclude=["temp*.py", "register.py", "test"]),
     include_package_data=True,
     license='MIT',
     description='SendGrid library for Python',


### PR DESCRIPTION
Sendgrid tests are installed into `<python_sitelib>/test` which may cause conflicts with other packages. We have run into this when building a package for Fedora (https://bugzilla.redhat.com/show_bug.cgi?id=1309244)

The solution would be to either exclude tests or install them under sendgrid directory (`<python_sitelib>/sendgrid/test`).