### PR TITLE
Don't include test module when installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     author='Elmer Thomas, Yamil Asusta',
     author_email='dx@sendgrid.com',
     url='https://github.com/sendgrid/sendgrid-python/',
-    packages=find_packages(exclude=["temp*.py"]),
+    packages=find_packages(exclude=["temp*.py", "test"]),
     include_package_data=True,
     license='MIT',
     description='SendGrid library for Python',


### PR DESCRIPTION
Currently, when the sendgrid package is installed, calling `import test` will import the sendgrid module.
This is likely to cause conflicts with other packages that use a top-level test module.

This patch adds the test module to the exclude list in `setup.py` so that it won't be bundled in built packages.  This will fix the namespace issue, and reduce the installed size.  It should not affect running the tests, as the tests will only ever be run from the unbuilt source.