### PR TITLE
Add ability to impersonate subuser

### DIFF
--- a/sendgrid/sendgrid.py
+++ b/sendgrid/sendgrid.py
@@ -20,15 +20,20 @@ class SendGridAPIClient(object):
         # Support v2 api_key naming
         self._apikey = opts.get('api_key', self._apikey)
         self._api_key = self._apikey
+        # Support impersonation of subusers
+        self._impersonate_subuser = opts.get('impersonate_subuser', None)
         self.useragent = 'sendgrid/{0};python'.format(__version__)
         self.host = opts.get('host', 'https://api.sendgrid.com')
         self.version = __version__
+
 
         headers = {
             "Authorization": 'Bearer {0}'.format(self._apikey),
             "User-agent": self.useragent,
             "Accept": 'application/json'
         }
+        if self._impersonate_subuser:
+            headers['On-Behalf-Of'] = self._impersonate_subuser
 
         self.client = python_http_client.Client(host=self.host,
                                                 request_headers=headers,
@@ -49,3 +54,7 @@ class SendGridAPIClient(object):
     @api_key.setter
     def api_key(self, value):
         self._apikey = value
+
+    @property
+    def impersonate_subuser(self):
+        return self._impersonate_subuser

--- a/test/test_sendgrid.py
+++ b/test/test_sendgrid.py
@@ -63,6 +63,14 @@ class UnitTests(unittest.TestCase):
         my_sendgrid = sendgrid.SendGridAPIClient(apikey="THISISMYKEY")
         self.assertEqual(my_sendgrid.apikey, "THISISMYKEY")
 
+    def test_impersonate_subuser_init(self):
+        temp_subuser = 'abcxyz@this.is.a.test.subuser'
+        sg_impersonate = sendgrid.SendGridAPIClient(
+            host=host, path=self.path,
+            api_key=os.environ.get('SENDGRID_API_KEY'),
+            impersonate_subuser=temp_subuser)
+        self.assertEqual(sg_impersonate.impersonate_subuser, temp_subuser)
+
     def test_useragent(self):
         useragent = '{0}{1}{2}'.format('sendgrid/', __version__, ';python')
         self.assertEqual(self.sg.useragent, useragent)


### PR DESCRIPTION
Sendgrid API has an (as yet) undocumented feature allowing parent accounts to impersonate
subusers by including an HTTP header "On-Behalf-Of" in each API request.
This commit enables setting the value for impersonation when creating the
Sendgrid API Client instance.