### PR TITLE
Add Docker for easy usage

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,9 @@ We welcome direct contributions to the sendgrid-python code base. Thank you!
 
 ### Development Environment ###
 
+#### Using Docker ####
+You can use our Docker image to avoid setting up the development environment yourself.  See [USAGE.md](https://github.com/sendgrid/sendgrid-python/docker/USAGE.md).
+
 #### Install and Run Locally ####
 
 ##### Prerequisites #####

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 [![Docker Badge](https://img.shields.io/docker/automated/sendgrid/sendgrid-python.svg)](https://hub.docker.com/r/sendgrid/sendgrid-python/)
 [![Email Notifications Badge](https://dx.sendgrid.com/badge/python)](https://dx.sendgrid.com/newsletter/python)
 
-**NEW:** Subscribe to email [notifications](https://dx.sendgrid.com/newsletter/python) for releases and breaking changes.
+**NEW:** Subscribe to email [notifications](https://dx.sendgrid.com/newsletter/python) for releases and breaking changes.  
+     Quickly get started with [Docker](https://github.com/sendgrid/sendgrid-python/docker/USAGE.md).
 
 **This library allows you to quickly and easily use the SendGrid Web API v3 via Python.**
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 [![Travis Badge](https://travis-ci.org/sendgrid/sendgrid-python.svg?branch=master)](https://travis-ci.org/sendgrid/sendgrid-python)
+[![Docker Badge](https://img.shields.io/docker/automated/sendgrid/sendgrid-python.svg)](https://hub.docker.com/r/sendgrid/sendgrid-python/)
 [![Email Notifications Badge](https://dx.sendgrid.com/badge/python)](https://dx.sendgrid.com/newsletter/python)
 
 **NEW:** Subscribe to email [notifications](https://dx.sendgrid.com/newsletter/python) for releases and breaking changes.

--- a/activate.sh
+++ b/activate.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-# Use this to activate the virtual environment, use the following to execute in current shell
-# . ./activate
-source venv/bin/activate

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:latest
+ENV PYTHON_VERSIONS='python2.6 python2.7 python3.4 python3.5 python3.6' \
+    OAI_SPEC_URL="https://raw.githubusercontent.com/sendgrid/sendgrid-oai/master/oai_stoplight.json"
+
+# install testing versions of python, including old versions, from deadsnakes
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends software-properties-common \
+    && apt-add-repository -y ppa:fkrull/deadsnakes \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends $PYTHON_VERSIONS \
+        git \
+        curl \
+    && apt-get purge -y --auto-remove software-properties-common \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /root
+
+# install Prism
+ADD https://raw.githubusercontent.com/stoplightio/prism/master/install.sh install.sh
+RUN chmod +x ./install.sh && \
+    ./install.sh && \
+    rm ./install.sh
+
+# install pip, tox
+ADD https://bootstrap.pypa.io/get-pip.py get-pip.py
+RUN python2.7 get-pip.py && \
+    pip install tox && \
+    rm get-pip.py
+
+# set up default sendgrid env
+WORKDIR /root/sources
+RUN git clone https://github.com/gabrielkrell/sendgrid-python.git && \
+    git clone https://github.com/sendgrid/python-http-client.git
+WORKDIR /root
+RUN ln -s /root/sources/sendgrid-python/sendgrid && \
+    ln -s /root/sources/python-http-client/python_http_client
+
+COPY entrypoint.sh entrypoint.sh
+RUN chmod +x entrypoint.sh
+ENTRYPOINT ["./entrypoint.sh"]
+CMD ["--mock"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:xenial
 ENV PYTHON_VERSIONS='python2.6 python2.7 python3.4 python3.5 python3.6' \
     OAI_SPEC_URL="https://raw.githubusercontent.com/sendgrid/sendgrid-oai/master/oai_stoplight.json"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,7 +30,7 @@ RUN python2.7 get-pip.py && \
 
 # set up default sendgrid env
 WORKDIR /root/sources
-RUN git clone https://github.com/gabrielkrell/sendgrid-python.git && \
+RUN git clone https://github.com/sendgrid/sendgrid-python.git && \
     git clone https://github.com/sendgrid/python-http-client.git
 WORKDIR /root
 RUN ln -s /root/sources/sendgrid-python/sendgrid && \

--- a/docker/README.md
+++ b/docker/README.md
@@ -25,7 +25,9 @@ You can mount repositories in the `/mnt/sendgrid-python` and `/mnt/python-http-c
 
 The easiest way to use an old version is to use an old tag.
 
-    $ docker run -it sendgrid/sendgrid-python:v3.6.1
+```sh-session
+$ docker run -it sendgrid/sendgrid-python:v3.6.1
+```
 
 Tags from before this Docker image was created might not exist yet. You may [manually download](#Versions) old versions in order to use them.
 
@@ -36,29 +38,35 @@ To use a different version of sendgrid-python or python-http-client - for instan
 
 For instance, to install sendgrid-python 3.6.1 and use the current python-http-client:
 
-    $ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
-    $ realpath sendgrid-python
-    /path/to/sendgrid-python
-    $ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
+```sh-session
+$ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
+$ realpath sendgrid-python
+/path/to/sendgrid-python
+$ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
+```
 
 To install sendgrid-python v3.6.1 and use an older version of python-http-client:
 
-    $ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
-    $ realpath sendgrid-python
-    /path/to/sendgrid-python
-    $ git clone https://github.com/sendgrid/python-http-client.git --branch v1.2.4
-    $ realpath python-http-client
-    /path/to/python-http-client
-    $ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python \
-                     -v /path/to/python-http-client:/mnt/python-http-client \
-                     sendgrid/sendgrid-python
+```sh-session
+$ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
+$ realpath sendgrid-python
+/path/to/sendgrid-python
+$ git clone https://github.com/sendgrid/python-http-client.git --branch v1.2.4
+$ realpath python-http-client
+/path/to/python-http-client
+$ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python \
+>                -v /path/to/python-http-client:/mnt/python-http-client \
+>                sendgrid/sendgrid-python
+```
 
 ## Specifying your own fork:
 
-    $ git clone https://github.com/you/cool-sendgrid-python.git
-    $ realpath cool-sendgrid-python
-    /path/to/cool-sendgrid-python
-    $ docker run -it -v /path/to/cool-sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
+```sh-session
+$ git clone https://github.com/you/cool-sendgrid-python.git
+$ realpath cool-sendgrid-python
+/path/to/cool-sendgrid-python
+$ docker run -it -v /path/to/cool-sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
+```
 
 Note that the paths you specify in `-v` must be absolute.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,7 +16,7 @@ This Docker image contains
 
 Run it in interactive mode with `-it`.
 
-You can mount repositories in the `/mnt/sendgrid-python` and `/mnt/python-http-client` directories to use them instead of the default SendGrid libraries.  Read on for more info.
+You can mount repositories in the `/mnt/sendgrid-python` and `/mnt/python-http-client` directories to use them instead of the default SendGrid libraries. Read on for more info.
 
 <a name="Options"></a>
 # Options
@@ -27,28 +27,28 @@ The easiest way to use an old version is to use an old tag.
 
     $ docker run -it sendgrid/sendgrid-python:v3.6.1
 
-Tags from before this Docker image was created might not exist yet.  You may [manually download](#Versions) old versions in order to use them.
+Tags from before this Docker image was created might not exist yet. You may [manually download](#Versions) old versions in order to use them.
 
 <a name="Versions"></a>
 ## Specifying a version
 
-To use a different version of sendgrid-python or python-http-client - for instance, to replicate your production setup - mount it with the `-v <host_dir>:<container_dir>` option.  When you put either repository under `/mnt`, the container will automatically detect it and make the proper symlinks.
+To use a different version of sendgrid-python or python-http-client - for instance, to replicate your production setup - mount it with the `-v <host_dir>:<container_dir>` option. When you put either repository under `/mnt`, the container will automatically detect it and make the proper symlinks. You can edit these files from the host machine while the container is running.
 
-For instance, to install sendgrid-python 3.6.1:
+For instance, to install sendgrid-python 3.6.1 and use the current python-http-client:
 
     $ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
     $ realpath sendgrid-python
-      /path/to/sendgrid-python
+    /path/to/sendgrid-python
     $ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
 
 To install sendgrid-python v3.6.1 and use an older version of python-http-client:
 
     $ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
     $ realpath sendgrid-python
-      /path/to/sendgrid-python
+    /path/to/sendgrid-python
     $ git clone https://github.com/sendgrid/python-http-client.git --branch v1.2.4
     $ realpath python-http-client
-      /path/to/python-http-client
+    /path/to/python-http-client
     $ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python \
                      -v /path/to/python-http-client:/mnt/python-http-client \
                      sendgrid/sendgrid-python
@@ -56,8 +56,8 @@ To install sendgrid-python v3.6.1 and use an older version of python-http-client
 ## Specifying your own fork:
 
     $ git clone https://github.com/you/cool-sendgrid-python.git
-    $ realpath sendgrid-python
-      /path/to/cool-sendgrid-python
+    $ realpath cool-sendgrid-python
+    /path/to/cool-sendgrid-python
     $ docker run -it -v /path/to/cool-sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
 
 Note that the paths you specify in `-v` must be absolute.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,11 +1,12 @@
-To easily install sendgrid-python, you can use Docker.
+You can use Docker to easily try out or test sendgrid-python.
 
-# Installation
+<a name="Quickstart"></a>
+# Quickstart
 
 1. Install Docker on your machine
-2. Pull the latest Docker image with `docker code here`
-3. Run it with `docker code here`.
+2. Run `docker run -it sendgrid/sendgrid-python`.
 
+<a name="Info"></a>
 # Info
 
 This Docker image contains
@@ -13,25 +14,51 @@ This Docker image contains
  - Stoplight's Prism, which lets you try out the API without actually sending email
  - A complete setup for testing the repository or your own fork
 
+You can mount repositories in the `/mnt/sendgrid-python` and `/mnt/python-http-client` directories to use them instead of the default SendGrid libraries.  Read on for more info.
+
+<a name="Options"></a>
 # Options
 
-To use a different version of sendgrid-python or python-http-client, mount it with the `-v <host_dir>:<container_dir>` option.  If you put it under `/mnt`, the container will automatically detect it and make the proper symlinks under root.
+The easiest way to use an old version is to use an old tag.
 
-For instance, to install v3.6.1:
+    $ docker run -it sendgrid/sendgrid-python:v3.6.1
 
-    $ DOCKER PULL CODE HERE
+Tags from before this Docker image was created may not exist.  You may download and mount old versions of the repository to use them.
+
+## Specifying a version
+
+To use a different version of sendgrid-python or python-http-client - for instance, to replicate your production setup - mount it with the `-v <host_dir>:<container_dir>` option.  When you put either repository under `/mnt`, the container will automatically detect it and make the proper symlinks.
+
+For instance, to install sendgrid-python v3.6.1 with an older version of python-http-client:
+
     $ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
     $ realpath sendgrid-python
-      /foo/sendgrid-python
-    $ DOCKER RUN CODE HERE
+      /path/to/sendgrid-python
+    $ git clone https://github.com/sendgrid/python-http-client.git --branch v1.2.4
+    $ realpath python-http-client
+      /path/to/python-http-client
+    $ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python \
+                     -v /path/to/python-http-client:/mnt/python-http-client \
+                     sendgrid/sendgrid-python
 
-To install your own version:
+## To install your own version:
 
-    $ DOCKER PULL CODE HERE
-    $ git clone https://github.com/foo/cool-sendgrid-python.git
+    $ git clone https://github.com/you/cool-sendgrid-python.git
     $ realpath sendgrid-python
-      /foo/cool-sendgrid-python
-    $ DOCKER RUN CODE HERE
+      /path/to/cool-sendgrid-python
+    $ docker run -it -v /path/to/cool-sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
 
+Note that the paths you specify in `-v` must be absolute.
+
+<a name="Testing"></a>
 # Testing
 Testing is easy!  Run the container, `cd sendgrid`, and run `tox`.
+
+<a name="about"></a>
+# About
+
+sendgrid-python is guided and supported by the SendGrid [Developer Experience Team](mailto:dx@sendgrid.com).
+
+sendgrid-python is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-python are trademarks of SendGrid, Inc.
+
+![SendGrid Logo](https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,3 +33,11 @@
    ```
 
 For more detailed information, see [USAGE.md](https://github.com/sendgrid/sendgrid-python/docker/USAGE.md).
+
+# About
+
+sendgrid-python is guided and supported by the SendGrid [Developer Experience Team](mailto:dx@sendgrid.com).
+
+sendgrid-python is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-python are trademarks of SendGrid, Inc.
+
+![SendGrid Logo](https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,12 +18,15 @@ This Docker image contains
 To use a different version of sendgrid-python or python-http-client, mount it with the `-v <host_dir>:<container_dir>` option.  If you put it under `/mnt`, the container will automatically detect it and make the proper symlinks under root.
 
 For instance, to install v3.6.1:
+
     $ DOCKER PULL CODE HERE
     $ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
     $ realpath sendgrid-python
       /foo/sendgrid-python
     $ DOCKER RUN CODE HERE
+
 To install your own version:
+
     $ DOCKER PULL CODE HERE
     $ git clone https://github.com/foo/cool-sendgrid-python.git
     $ realpath sendgrid-python
@@ -31,4 +34,4 @@ To install your own version:
     $ DOCKER RUN CODE HERE
 
 # Testing
-Testing is easy!  Just `cd sendgrid` and run `tox`.
+Testing is easy!  Run the container, `cd sendgrid`, and run `tox`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,84 +1,35 @@
-You can use Docker to easily try out or test sendgrid-python.
+# Supported tags and respective `Dockerfile` links
+ - `latest` [(Dockerfile)](https://github.com/sendgrid/sendgrid-python/blob/master/docker/Dockerfile)
 
-<a name="Quickstart"></a>
-# Quickstart
+# Quick reference
+ - **Where to get help:**
+   [contact SendGrid Support](https://support.sendgrid.com/hc/en-us)
 
-1. Install Docker on your machine.
-2. Run `docker run -it sendgrid/sendgrid-python`.
+ - **Where to file issues:**
+   https://github.com/sendgrid/sendgrid-python/issues
 
-<a name="Info"></a>
-# Info
+ - **Where to get more info:**
+   [USAGE.md](https://github.com/sendgrid/sendgrid-python/docker/USAGE.md)
 
-This Docker image contains
- - `sendgrid-python` and `python-http-client`
- - Stoplight's Prism, which lets you try out the API without actually sending email
- - `tox` and all supported Python versions, set up to test `sendgrid-python` or your own fork
+ - **Maintained by:**
+   [SendGrid Inc.](https://sendgrid.com)
 
-Run it in interactive mode with `-it`.
+# Usage examples
+ - Most recent version: `docker run -it sendgrid/sendgrid-python`.
+ - Old version: `docker run -it sendgrid/sendgrid-python:v4.2.0`
+ - Old version predating this Docker image:
+   ```sh-session
+   $ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
+   $ realpath sendgrid-python
+   /path/to/sendgrid-python
+   $ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
+   ```
+ - Your own fork:
+   ```sh-session
+   $ git clone https://github.com/you/cool-sendgrid-python.git
+   $ realpath cool-sendgrid-python
+   /path/to/cool-sendgrid-python
+   $ docker run -it -v /path/to/cool-sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
+   ```
 
-You can mount repositories in the `/mnt/sendgrid-python` and `/mnt/python-http-client` directories to use them instead of the default SendGrid libraries. Read on for more info.
-
-<a name="Options"></a>
-# Options
-
-## Using an old version
-
-The easiest way to use an old version is to use an [old tag](https://github.com/sendgrid/sendgrid-python/releases).
-
-```sh-session
-$ docker run -it sendgrid/sendgrid-python:v3.6.1
-```
-
-Tags from before this Docker image was created might not exist yet. You may [manually download](#Versions) [old versions](https://github.com/sendgrid/sendgrid-python/releases) in order to use them.
-
-<a name="Versions"></a>
-## Specifying specific versions
-
-To use different versions of sendgrid-python or python-http-client - for instance, to replicate your production setup - mount them with the `-v <host_dir>:<container_dir>` option. When you put either repository under `/mnt`, the container will automatically detect it and make the proper symlinks. You can edit these files from the host machine while the container is running.
-
-For instance, to install sendgrid-python 3.6.1 and use the current python-http-client:
-
-```sh-session
-$ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
-$ realpath sendgrid-python
-/path/to/sendgrid-python
-$ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
-```
-
-To install sendgrid-python v3.6.1 and use an older version of python-http-client:
-
-```sh-session
-$ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
-$ realpath sendgrid-python
-/path/to/sendgrid-python
-$ git clone https://github.com/sendgrid/python-http-client.git --branch v1.2.4
-$ realpath python-http-client
-/path/to/python-http-client
-$ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python \
->                -v /path/to/python-http-client:/mnt/python-http-client \
->                sendgrid/sendgrid-python
-```
-
-## Specifying your own fork:
-
-```sh-session
-$ git clone https://github.com/you/cool-sendgrid-python.git
-$ realpath cool-sendgrid-python
-/path/to/cool-sendgrid-python
-$ docker run -it -v /path/to/cool-sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
-```
-
-Note that the paths you specify in `-v` must be absolute.
-
-<a name="Testing"></a>
-# Testing
-Testing is easy!  Run the container, `cd sendgrid`, and run `tox`.
-
-<a name="about"></a>
-# About
-
-sendgrid-python is guided and supported by the SendGrid [Developer Experience Team](mailto:dx@sendgrid.com).
-
-sendgrid-python is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-python are trademarks of SendGrid, Inc.
-
-![SendGrid Logo](https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)
+For more detailed information, see [USAGE.md](https://github.com/sendgrid/sendgrid-python/docker/USAGE.md).

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,34 @@
+To easily install sendgrid-python, you can use Docker.
+
+# Installation
+
+1. Install Docker on your machine
+2. Pull the latest Docker image with `docker code here`
+3. Run it with `docker code here`.
+
+# Info
+
+This Docker image contains
+ - `sendgrid-python` and `python-http-client`
+ - Stoplight's Prism, which lets you try out the API without actually sending email
+ - A complete setup for testing the repository or your own fork
+
+# Options
+
+To use a different version of sendgrid-python or python-http-client, mount it with the `-v <host_dir>:<container_dir>` option.  If you put it under `/mnt`, the container will automatically detect it and make the proper symlinks under root.
+
+For instance, to install v3.6.1:
+    $ DOCKER PULL CODE HERE
+    $ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
+    $ realpath sendgrid-python
+      /foo/sendgrid-python
+    $ DOCKER RUN CODE HERE
+To install your own version:
+    $ DOCKER PULL CODE HERE
+    $ git clone https://github.com/foo/cool-sendgrid-python.git
+    $ realpath sendgrid-python
+      /foo/cool-sendgrid-python
+    $ DOCKER RUN CODE HERE
+
+# Testing
+Testing is easy!  Just `cd sendgrid` and run `tox`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -3,7 +3,7 @@ You can use Docker to easily try out or test sendgrid-python.
 <a name="Quickstart"></a>
 # Quickstart
 
-1. Install Docker on your machine
+1. Install Docker on your machine.
 2. Run `docker run -it sendgrid/sendgrid-python`.
 
 <a name="Info"></a>
@@ -14,22 +14,34 @@ This Docker image contains
  - Stoplight's Prism, which lets you try out the API without actually sending email
  - A complete setup for testing the repository or your own fork
 
+Run it in interactive mode with `-it`.
+
 You can mount repositories in the `/mnt/sendgrid-python` and `/mnt/python-http-client` directories to use them instead of the default SendGrid libraries.  Read on for more info.
 
 <a name="Options"></a>
 # Options
 
+## Using an old version
+
 The easiest way to use an old version is to use an old tag.
 
     $ docker run -it sendgrid/sendgrid-python:v3.6.1
 
-Tags from before this Docker image was created may not exist.  You may download and mount old versions of the repository to use them.
+Tags from before this Docker image was created might not exist yet.  You may [manually download](#Versions) old versions in order to use them.
 
+<a name="Versions"></a>
 ## Specifying a version
 
 To use a different version of sendgrid-python or python-http-client - for instance, to replicate your production setup - mount it with the `-v <host_dir>:<container_dir>` option.  When you put either repository under `/mnt`, the container will automatically detect it and make the proper symlinks.
 
-For instance, to install sendgrid-python v3.6.1 with an older version of python-http-client:
+For instance, to install sendgrid-python 3.6.1:
+
+    $ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
+    $ realpath sendgrid-python
+      /path/to/sendgrid-python
+    $ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
+
+To install sendgrid-python v3.6.1 and use an older version of python-http-client:
 
     $ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
     $ realpath sendgrid-python
@@ -41,7 +53,7 @@ For instance, to install sendgrid-python v3.6.1 with an older version of python-
                      -v /path/to/python-http-client:/mnt/python-http-client \
                      sendgrid/sendgrid-python
 
-## To install your own version:
+## Specifying your own fork:
 
     $ git clone https://github.com/you/cool-sendgrid-python.git
     $ realpath sendgrid-python

--- a/docker/README.md
+++ b/docker/README.md
@@ -12,7 +12,7 @@ You can use Docker to easily try out or test sendgrid-python.
 This Docker image contains
  - `sendgrid-python` and `python-http-client`
  - Stoplight's Prism, which lets you try out the API without actually sending email
- - A complete setup for testing the repository or your own fork
+ - `tox` and all supported Python versions, set up to test `sendgrid-python` or your own fork
 
 Run it in interactive mode with `-it`.
 
@@ -23,18 +23,18 @@ You can mount repositories in the `/mnt/sendgrid-python` and `/mnt/python-http-c
 
 ## Using an old version
 
-The easiest way to use an old version is to use an old tag.
+The easiest way to use an old version is to use an [old tag](https://github.com/sendgrid/sendgrid-python/releases).
 
 ```sh-session
 $ docker run -it sendgrid/sendgrid-python:v3.6.1
 ```
 
-Tags from before this Docker image was created might not exist yet. You may [manually download](#Versions) old versions in order to use them.
+Tags from before this Docker image was created might not exist yet. You may [manually download](#Versions) [old versions](https://github.com/sendgrid/sendgrid-python/releases) in order to use them.
 
 <a name="Versions"></a>
-## Specifying a version
+## Specifying specific versions
 
-To use a different version of sendgrid-python or python-http-client - for instance, to replicate your production setup - mount it with the `-v <host_dir>:<container_dir>` option. When you put either repository under `/mnt`, the container will automatically detect it and make the proper symlinks. You can edit these files from the host machine while the container is running.
+To use different versions of sendgrid-python or python-http-client - for instance, to replicate your production setup - mount them with the `-v <host_dir>:<container_dir>` option. When you put either repository under `/mnt`, the container will automatically detect it and make the proper symlinks. You can edit these files from the host machine while the container is running.
 
 For instance, to install sendgrid-python 3.6.1 and use the current python-http-client:
 

--- a/docker/USAGE.md
+++ b/docker/USAGE.md
@@ -1,0 +1,84 @@
+You can use Docker to easily try out or test sendgrid-python.
+
+<a name="Quickstart"></a>
+# Quickstart
+
+1. Install Docker on your machine.
+2. Run `docker run -it sendgrid/sendgrid-python`.
+
+<a name="Info"></a>
+# Info
+
+This Docker image contains
+ - `sendgrid-python` and `python-http-client`
+ - Stoplight's Prism, which lets you try out the API without actually sending email
+ - `tox` and all supported Python versions, set up to test `sendgrid-python` or your own fork
+
+Run it in interactive mode with `-it`.
+
+You can mount repositories in the `/mnt/sendgrid-python` and `/mnt/python-http-client` directories to use them instead of the default SendGrid libraries. Read on for more info.
+
+<a name="Options"></a>
+# Options
+
+## Using an old version
+
+The easiest way to use an old version is to use an [old tag](https://github.com/sendgrid/sendgrid-python/releases).
+
+```sh-session
+$ docker run -it sendgrid/sendgrid-python:v3.6.1
+```
+
+Tags from before this Docker image was created might not exist yet. You may [manually download](#Versions) [old versions](https://github.com/sendgrid/sendgrid-python/releases) in order to use them.
+
+<a name="Versions"></a>
+## Specifying specific versions
+
+To use different versions of sendgrid-python or python-http-client - for instance, to replicate your production setup - mount them with the `-v <host_dir>:<container_dir>` option. When you put either repository under `/mnt`, the container will automatically detect it and make the proper symlinks. You can edit these files from the host machine while the container is running.
+
+For instance, to install sendgrid-python 3.6.1 and use the current python-http-client:
+
+```sh-session
+$ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
+$ realpath sendgrid-python
+/path/to/sendgrid-python
+$ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
+```
+
+To install sendgrid-python v3.6.1 and use an older version of python-http-client:
+
+```sh-session
+$ git clone https://github.com/sendgrid/sendgrid-python.git --branch v3.6.1
+$ realpath sendgrid-python
+/path/to/sendgrid-python
+$ git clone https://github.com/sendgrid/python-http-client.git --branch v1.2.4
+$ realpath python-http-client
+/path/to/python-http-client
+$ docker run -it -v /path/to/sendgrid-python:/mnt/sendgrid-python \
+>                -v /path/to/python-http-client:/mnt/python-http-client \
+>                sendgrid/sendgrid-python
+```
+
+## Specifying your own fork:
+
+```sh-session
+$ git clone https://github.com/you/cool-sendgrid-python.git
+$ realpath cool-sendgrid-python
+/path/to/cool-sendgrid-python
+$ docker run -it -v /path/to/cool-sendgrid-python:/mnt/sendgrid-python sendgrid/sendgrid-python
+```
+
+Note that the paths you specify in `-v` must be absolute.
+
+<a name="Testing"></a>
+# Testing
+Testing is easy!  Run the container, `cd sendgrid`, and run `tox`.
+
+<a name="about"></a>
+# About
+
+sendgrid-python is guided and supported by the SendGrid [Developer Experience Team](mailto:dx@sendgrid.com).
+
+sendgrid-python is maintained and funded by SendGrid, Inc. The names and logos for sendgrid-python are trademarks of SendGrid, Inc.
+
+![SendGrid Logo](https://uiux.s3.amazonaws.com/2016-logos/email-logo%402x.png)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -16,15 +16,16 @@ then
 fi
 
 SENDGRID_PYTHON_VERSION=$(python2.7 -c 'import sendgrid; print(sendgrid.__version__)')
-echo "Welcome to the sendgrid-python docker (version $SENDGRID_PYTHON_VERSION)"
+echo "Welcome to sendgrid-python docker v${SENDGRID_PYTHON_VERSION}."
 echo
 
 if [ "$1" != "--no-mock" ]
 then
-	echo "Starting Prism in mock mode. Disable this by running this container with --no-mock."
+	echo "Starting Prism in mock mode. Calls made to Prism will not actually send emails."
+	echo "Disable this by running this container with --no-mock."
 	prism run --mock --spec $OAI_SPEC_URL 2> /dev/null &
 else
-	echo "Starting Prism in live (passthrough) mode. You can send emails as normal."
+	echo "Starting Prism in live (--no-mock) mode. Calls made to Prism will send emails."
 	prism run --spec $OAI_SPEC_URL 2> /dev/null  &
 fi
 echo "To use Prism, make API calls to localhost:4010. For example,"
@@ -34,14 +35,14 @@ echo "        api_key=os.environ.get('SENDGRID_API_KEY_CAMPAIGNS'))"
 echo "To stop Prism, run \"kill $!\" from the shell."
 
 echo
-echo "Starting python. Type \"import sendgrid\" to get started; return to shell with exit()."
-echo "To test sendgrid-python, \"cd sendgrid\" and run \"tox\"."
+echo "Starting Python. Type \"import sendgrid\" to get started; return to shell with exit()."
 echo
 
 python2.7
 
 echo
-echo "When you want to get back into Python, here are the installed versions:"
-echo "$PYTHON_VERSIONS"
+echo "To get back into Python, run one of the installed versions:"
+echo "    $PYTHON_VERSIONS"
+echo "To test sendgrid-python, \"cd sendgrid\" and run \"tox\"."
 echo
 exec $SHELL

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,52 @@
+#! /bin/bash
+
+# script to handle Docker startup.  Cases:
+# - start Prism in mock mode, open Python (default)
+# - start Prism in live mode, open Python (--no-mock)
+
+clear
+
+# check for + link mounted libraries:
+if [ -d /mnt/sendgrid-python ]
+then
+	rm /root/sendgrid
+	ln -s /mnt/sendgrid-python/sendgrid
+	echo "Linked mounted sendgrid-python's code to /root/sendgrid"
+fi
+
+if [ -d /mnt/python_http_client ]
+then
+	rm /root/python_http_client
+	ln -s /mnt/python-http-client/python_http_client
+	echo "Linked mounted python-http-client's code to /root/python_http_client"
+fi
+
+SENDGRID_PYTHON_VERSION=$(python2.7 -c 'import sendgrid; print(sendgrid.__version__)')
+
+echo "Welcome to the sendgrid-python docker (version $SENDGRID_PYTHON_VERSION)"
+echo ""
+
+if [ "$1" != "--no-mock" ]
+then
+	echo "Starting Prism in mock mode.  You can make SendGrid API calls without spending emails."
+	echo "	Disable by running this container with --no-mock."
+	prism run --mock --spec $OAI_SPEC_URL 2> /dev/null &
+else
+	echo "Starting Prism in live (passthrough) mode.  You can send emails as normal."
+	prism run --spec $OAI_SPEC_URL 2> /dev/null  &
+fi
+echo "	To use Prism, make API calls to localhost:4010.  For example,"
+echo "		sg = sendgrid.SendGridAPIClient("
+echo "			host='http://localhost:4010/',"
+echo "			api_key=os.environ.get('SENDGRID_API_KEY_CAMPAIGNS'))"
+echo "	To stop Prism, run \"kill $!\" from the shell."
+
+echo
+echo "Starting python.  Type \"import sendgrid\" to get started; return to shell with exit()."
+echo "To test sendgrid-python, \"cd sendgrid\" and run \"tox\"."
+
+python2.7
+
+echo "When you want to get back into Python, here are the installed versions:"
+echo "	$PYTHON_VERSIONS"
+exec $SHELL

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,9 +1,4 @@
 #! /bin/bash
-
-# script to handle Docker startup.  Cases:
-# - start Prism in mock mode, open Python (default)
-# - start Prism in live mode, open Python (--no-mock)
-
 clear
 
 # check for + link mounted libraries:
@@ -13,7 +8,6 @@ then
 	ln -s /mnt/sendgrid-python/sendgrid
 	echo "Linked mounted sendgrid-python's code to /root/sendgrid"
 fi
-
 if [ -d /mnt/python_http_client ]
 then
 	rm /root/python_http_client
@@ -22,31 +16,32 @@ then
 fi
 
 SENDGRID_PYTHON_VERSION=$(python2.7 -c 'import sendgrid; print(sendgrid.__version__)')
-
 echo "Welcome to the sendgrid-python docker (version $SENDGRID_PYTHON_VERSION)"
-echo ""
+echo
 
 if [ "$1" != "--no-mock" ]
 then
-	echo "Starting Prism in mock mode.  You can make SendGrid API calls without spending emails."
-	echo "	Disable by running this container with --no-mock."
+	echo "Starting Prism in mock mode. Disable this by running this container with --no-mock."
 	prism run --mock --spec $OAI_SPEC_URL 2> /dev/null &
 else
-	echo "Starting Prism in live (passthrough) mode.  You can send emails as normal."
+	echo "Starting Prism in live (passthrough) mode. You can send emails as normal."
 	prism run --spec $OAI_SPEC_URL 2> /dev/null  &
 fi
-echo "	To use Prism, make API calls to localhost:4010.  For example,"
-echo "		sg = sendgrid.SendGridAPIClient("
-echo "			host='http://localhost:4010/',"
-echo "			api_key=os.environ.get('SENDGRID_API_KEY_CAMPAIGNS'))"
-echo "	To stop Prism, run \"kill $!\" from the shell."
+echo "To use Prism, make API calls to localhost:4010. For example,"
+echo "    sg = sendgrid.SendGridAPIClient("
+echo "        host='http://localhost:4010/',"
+echo "        api_key=os.environ.get('SENDGRID_API_KEY_CAMPAIGNS'))"
+echo "To stop Prism, run \"kill $!\" from the shell."
 
 echo
-echo "Starting python.  Type \"import sendgrid\" to get started; return to shell with exit()."
+echo "Starting python. Type \"import sendgrid\" to get started; return to shell with exit()."
 echo "To test sendgrid-python, \"cd sendgrid\" and run \"tox\"."
+echo
 
 python2.7
 
+echo
 echo "When you want to get back into Python, here are the installed versions:"
-echo "	$PYTHON_VERSIONS"
+echo "$PYTHON_VERSIONS"
+echo
 exec $SHELL

--- a/test/test_sendgrid.py
+++ b/test/test_sendgrid.py
@@ -33,8 +33,9 @@ class UnitTests(unittest.TestCase):
                             "https://raw.githubusercontent.com/stoplightio/"
                             "prism/master/install.sh"],
                         stdout=subprocess.PIPE)
-                    subprocess.Popen(
+                    prisminstaller = subprocess.Popen(
                         ["sh"], stdin=p1.stdout, stdout=subprocess.PIPE)
+                    prisminstaller.wait()
                 except Exception as e:
                     print(
                         "Error downloading the prism binary, you can try "

--- a/tox.ini
+++ b/tox.ini
@@ -4,44 +4,34 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36
+envlist = py26, py27, py34, py35, py36
 
 [testenv]
 commands = {envbindir}/python -m unittest discover -v []
-deps =
-    {py26,py27,py32,py33,py34,py35,py36}-full: python_http_client
+deps = -rrequirements.txt
 
 [testenv:py26]
 commands = {envbindir}/unit2 discover -v []
 deps = unittest2
+       {[testenv]deps}
 basepython = python2.6
 
 [testenv:py27]
 commands = {envbindir}/python -m unittest discover -v []
-deps = 
+deps = {[testenv]deps}
 basepython = python2.7
-
-[testenv:py32]
-commands = {envbindir}/python -m unittest discover -v []
-deps = 
-basepython = python3.2
-
-[testenv:py33]
-commands = {envbindir}/python -m unittest discover -v []
-deps = 
-basepython = python3.3
 
 [testenv:py34]
 commands = {envbindir}/python -m unittest discover -v []
-deps = 
+deps = {[testenv]deps}
 basepython = python3.4
 
 [testenv:py35]
 commands = {envbindir}/python -m unittest discover -v []
-deps = -rrequirements.txt
+deps = {[testenv]deps}
 basepython = python3.5
 
 [testenv:py36]
 commands = {envbindir}/python -m unittest discover -v []
-deps = -rrequirements.txt
+deps = {[testenv]deps}
 basepython = python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -17,21 +17,21 @@ deps = unittest2
 basepython = python2.6
 
 [testenv:py27]
-commands = {envbindir}/python -m unittest discover -v []
+commands = {[testenv]commands}
 deps = {[testenv]deps}
 basepython = python2.7
 
 [testenv:py34]
-commands = {envbindir}/python -m unittest discover -v []
+commands = {[testenv]commands}
 deps = {[testenv]deps}
 basepython = python3.4
 
 [testenv:py35]
-commands = {envbindir}/python -m unittest discover -v []
+commands = {[testenv]commands}
 deps = {[testenv]deps}
 basepython = python3.5
 
 [testenv:py36]
-commands = {envbindir}/python -m unittest discover -v []
+commands = {[testenv]commands}
 deps = {[testenv]deps}
 basepython = python3.6


### PR DESCRIPTION
Add a Docker container to make it easier to try out or contribute to sendgrid-python.

 - Add Dockerfile, startup shell script, readme
 - Update+improve `tox.ini`
 - Prism install bugfix

Note: Don't approve until sendgrid/python Docker Hub has been created + linked.  Also, should probably be squashed based on # of tiny commits.