### PR TITLE
Change usage example "retrieve all campaigns"

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -790,7 +790,7 @@ For more information:
 
 
 ```python
-params = {'limit': 1, 'offset': 1}
+params = {'limit': 10, 'offset': 0}
 response = sg.client.campaigns.get(query_params=params)
 print response.status_code
 print response.body


### PR DESCRIPTION
Change example code for "retrieve all campaigns" to use the default parameters of limit 10, no offset instead of getting a single campaign with offset 1.  This threw me for a loop a couple weeks ago when I was getting started.