### PR TITLE
Permit unicode string values with Substitution helper

### DIFF
--- a/sendgrid/helpers/mail/mail.py
+++ b/sendgrid/helpers/mail/mail.py
@@ -384,7 +384,7 @@ class Substitution(object):
 
     @key.setter
     def key(self, value):
-        self._key = str(value)
+        self._key = value
 
     @property
     def value(self):
@@ -392,7 +392,7 @@ class Substitution(object):
 
     @value.setter
     def value(self, value):
-        self._value = str(value)
+        self._value = value
 
     def get(self):
         substitution = {}

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 import json
 
 from sendgrid.helpers.mail import (
@@ -402,6 +403,64 @@ class UnitTests(unittest.TestCase):
                 }
             }
         }
+        self.assertEqual(
+            json.dumps(mail.get(), sort_keys=True),
+            json.dumps(expected_result, sort_keys=True)
+        )
+
+    def test_unicode_values_in_substitutions_helper(self):
+
+        """ Test that the Substitutions helper accepts unicode values """
+
+        self.maxDiff = None
+
+        """Minimum required to send an email"""
+        mail = Mail()
+
+        mail.from_email = Email("test@example.com")
+
+        mail.subject = "Testing unicode substitutions with the SendGrid Python Library"
+
+        personalization = Personalization()
+        personalization.add_to(Email("test@example.com"))
+        personalization.add_substitution(Substitution("%city%", u"Αθήνα"))
+        mail.add_personalization(personalization)
+
+        mail.add_content(Content("text/plain", "some text here"))
+        mail.add_content(
+            Content(
+                "text/html",
+                "<html><body>some text here</body></html>"))
+
+        expected_result = {
+            "content": [
+                {
+                    "type": "text/plain",
+                    "value": "some text here"
+                },
+                {
+                    "type": "text/html",
+                    "value": "<html><body>some text here</body></html>"
+                }
+            ],
+            "from": {
+                "email": "test@example.com"
+            },
+            "personalizations": [
+                {
+                    "substitutions": {
+                        "%city%": u"Αθήνα"
+                    },
+                    "to": [
+                        {
+                            "email": "test@example.com"
+                        }
+                    ]
+                }
+            ],
+            "subject": "Testing unicode substitutions with the SendGrid Python Library",
+        }
+
         self.assertEqual(
             json.dumps(mail.get(), sort_keys=True),
             json.dumps(expected_result, sort_keys=True)


### PR DESCRIPTION
This PR addresses issue #334 

The issue was with using unicode values in substitutions. In this PR, I removed forced casting to ascii for values used with Substitutions. It seems that other helpers don't cast values to ascii.

Example code that would cause an error:

`personalization.add_substitution(Substitution("%city%", u"Αθήνα"))`

I created a simple test to see that the Substitutions helper can now handle a unicode string. All tests pass.

I also tested this in an end-to-end workflow, where we submitted data into our form and received a live email with unicode values where expected.

This is my first public pull request on Github, please let me know if I am missing anything required here.