### PR TITLE
Install prism with non superuser account 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,8 @@ addons:
   apt_packages:
     - pandoc
 before_script:
-- mkdir prism
-- mkdir prism/bin
-- export PATH=$PATH:$PWD/prism/bin/
-- ./test/prism.sh
+- . ./test/prism.sh
+- prism version
 script:
 - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then unit2 discover; else python -m unittest
   discover; fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,6 +137,7 @@ The above local "Initial setup" is complete
 
 * [pyenv](https://github.com/yyuu/pyenv)
 * [tox](https://pypi.python.org/pypi/tox)
+* [prism](https://github.com/stoplightio/prism) v0.6 - you can also install it locally by using `test/prism.sh` script
 
 #### Initial setup: ####
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -137,7 +137,9 @@ The above local "Initial setup" is complete
 
 * [pyenv](https://github.com/yyuu/pyenv)
 * [tox](https://pypi.python.org/pypi/tox)
-* [prism](https://github.com/stoplightio/prism) v0.6 - you can also install it locally by using `test/prism.sh` script
+* [prism](https://github.com/stoplightio/prism) v0.6 - It should be available in your PATH, but unittest script
+will try to install it locally if not found. Apart from PATH env variable it will check in `~/bin` and `/usr/local/bin`.
+You can install by yourself it in user dir by calling `source test/prism.sh`.
 
 #### Initial setup: ####
 

--- a/test/prism.sh
+++ b/test/prism.sh
@@ -28,7 +28,7 @@ fi
 #LATEST=$(curl -s https://api.github.com/repos/stoplightio/prism/tags | grep -Eo '"name":.*?[^\\]",'  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
 LATEST="v0.6.21"
 URL="https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
-DESTDIR=./prism/bin
+DESTDIR=~/bin
 DEST=$DESTDIR/prism
 
 if [ -z $LATEST ] ; then

--- a/test/prism.sh
+++ b/test/prism.sh
@@ -26,17 +26,24 @@ elif [ "$UNAME" = "Linux" ] ; then
 fi
 
 #LATEST=$(curl -s https://api.github.com/repos/stoplightio/prism/tags | grep -Eo '"name":.*?[^\\]",'  | head -n 1 | sed 's/[," ]//g' | cut -d ':' -f 2)
-LATEST="v0.1.5"
+LATEST="v0.6.21"
 URL="https://github.com/stoplightio/prism/releases/download/$LATEST/prism_$PLATFORM"
-DEST=./prism/bin/prism
+DESTDIR=./prism/bin
+DEST=$DESTDIR/prism
 
 if [ -z $LATEST ] ; then
   echo "Error requesting. Download binary from ${URL}"
   exit 1
 else
+  mkdir -p $DESTDIR
   curl -L $URL -o $DEST
   chmod +x $DEST
+  export PATH=$PATH:$DESTDIR
+  prism version
 fi
 }
 
 install
+
+# this is needed for travis internal scripts
+set +u

--- a/test/test_sendgrid.py
+++ b/test/test_sendgrid.py
@@ -24,37 +24,51 @@ class UnitTests(unittest.TestCase):
         cls.sg = sendgrid.SendGridAPIClient(
             host=host, path=cls.path,
             api_key=os.environ.get('SENDGRID_API_KEY'))
-        if os.path.isfile('/usr/local/bin/prism') is False:
+        cls.devnull = open(os.devnull, 'w')
+        prism_cmd = None
+        try:
+            # check for prism in the PATH
+            if subprocess.call('prism version'.split(), stdout=cls.devnull) == 0:
+                prism_cmd = 'prism'
+        except OSError:
+            prism_cmd = None
+
+        if not prism_cmd:
+            # check for known prism locations
+            for path in ('/usr/local/bin/prism', os.path.expanduser(os.path.join('~', 'bin', 'prism')),
+                         os.path.abspath(os.path.join(os.getcwd(), 'prism', 'bin', 'prism'))):
+                prism_cmd = path if os.path.isfile(path) else None
+                if prism_cmd:
+                    break
+
+        if not prism_cmd:
             if sys.platform != 'win32':
+                # try to install with prism.sh
                 try:
-                    p1 = subprocess.Popen(
-                        [
-                            "curl",
-                            "https://raw.githubusercontent.com/stoplightio/"
-                            "prism/master/install.sh"],
-                        stdout=subprocess.PIPE)
-                    prisminstaller = subprocess.Popen(
-                        ["sh"], stdin=p1.stdout, stdout=subprocess.PIPE)
-                    prisminstaller.wait()
+                    print("Warning: no prism detected, I will try to install it locally")
+                    prism_sh = os.path.abspath(os.path.join(cls.path, 'test', 'prism.sh'))
+                    if subprocess.call(prism_sh) == 0:
+                        prism_cmd = os.path.expanduser(os.path.join('~', 'bin', 'prism'))
+                    else:
+                        raise RuntimeError()
                 except Exception as e:
                     print(
-                        "Error downloading the prism binary, you can try "
+                        "Error installing the prism binary, you can try "
                         "downloading directly here "
                         "(https://github.com/stoplightio/prism/releases) "
-                        "and place in your /usr/local/bin directory",
-                        e.read())
+                        "and place in your $PATH", e)
                     sys.exit()
             else:
                 print("Please download the Windows binary "
                       "(https://github.com/stoplightio/prism/releases) "
-                      "and place it in your /usr/local/bin directory")
+                      "and place it in your %PATH% ")
                 sys.exit()
+
         print("Activating Prism (~20 seconds)")
-        devnull = open(os.devnull, 'w')
         cls.p = subprocess.Popen([
-            "prism", "run", "-s",
+            prism_cmd, "run", "-s",
             "https://raw.githubusercontent.com/sendgrid/sendgrid-oai/master/"
-            "oai_stoplight.json"], stdout=devnull, stderr=subprocess.STDOUT)
+            "oai_stoplight.json"], stdout=cls.devnull, stderr=subprocess.STDOUT)
         time.sleep(15)
         print("Prism Started")
 


### PR DESCRIPTION
This changes the install method used in unittests to test/prism.sh script.
prism.sh downloads latest stable (pre 2.0alpha - currently v0.6) and installs it into ~/bin directory.

Unittests will check for prism command in the PATH and few known locations (among them ~/bin dir) and if prism is not found, it will launch the prism script to install it and use the newly installed binary.

CONTRIBUTING page was updated with new procedure info

Fixes #311