### PR TITLE
Provide utf-8 as encoding explicitly when opening text files

### DIFF
--- a/register.py
+++ b/register.py
@@ -1,11 +1,11 @@
 import pypandoc
-import io
+from io import open
 
 output = pypandoc.convert('README.md', 'rst')
 with open('README.txt' 'w+') as f:
     f.write(str(output.encode('utf-8')))
 
-readme_rst = io.open('./README.txt', 'r', encoding='utf-8').read()
+readme_rst = open('./README.txt', 'r', encoding='utf-8').read()
 replace = '''
             .. figure:: https://uiux.s3.amazonaws.com/2016-logos/email-logo
             %402x.png\n   :alt: SendGrid Logo\n\n   SendGrid Logo\n
@@ -16,5 +16,5 @@ replacement = '''
                 \n   :target: https://www.sendgrid.com
               '''
 final_text = readme_rst.replace(replace, replacement)
-with io.open('./README.txt', 'w', encoding='utf-8') as f:
+with open('./README.txt', 'w', encoding='utf-8') as f:
   f.write(final_text)

--- a/register.py
+++ b/register.py
@@ -1,10 +1,11 @@
 import pypandoc
+import io
 
 output = pypandoc.convert('README.md', 'rst')
 with open('README.txt' 'w+') as f:
     f.write(str(output.encode('utf-8')))
 
-readme_rst = open('./README.txt').read()
+readme_rst = io.open('./README.txt', 'r', encoding='utf-8').read()
 replace = '''
             .. figure:: https://uiux.s3.amazonaws.com/2016-logos/email-logo
             %402x.png\n   :alt: SendGrid Logo\n\n   SendGrid Logo\n
@@ -15,5 +16,5 @@ replacement = '''
                 \n   :target: https://www.sendgrid.com
               '''
 final_text = readme_rst.replace(replace, replacement)
-with open('./README.txt', 'w') as f:
-    f.write(final_text)
+with io.open('./README.txt', 'w', encoding='utf-8') as f:
+  f.write(final_text)

--- a/sendgrid/helpers/inbound/send.py
+++ b/sendgrid/helpers/inbound/send.py
@@ -2,7 +2,7 @@
 Usage: ./send.py [path to file containing test data]"""
 import argparse
 import sys
-import io
+from io import open
 try:
     from config import Config
 except ImportError:
@@ -27,7 +27,7 @@ class Send(object):
             "Content-Type": "multipart/form-data; boundary=xYzZY"
         }
         client = Client(host=self.url, request_headers=headers)
-        f = io.open(payload_filepath, 'r', encoding='utf-8')
+        f = open(payload_filepath, 'r', encoding='utf-8')
         data = f.read()
         return client.post(request_body=data)
 

--- a/sendgrid/helpers/inbound/send.py
+++ b/sendgrid/helpers/inbound/send.py
@@ -2,6 +2,7 @@
 Usage: ./send.py [path to file containing test data]"""
 import argparse
 import sys
+import io
 try:
     from config import Config
 except ImportError:
@@ -26,7 +27,7 @@ class Send(object):
             "Content-Type": "multipart/form-data; boundary=xYzZY"
         }
         client = Client(host=self.url, request_headers=headers)
-        f = open(payload_filepath, 'r')
+        f = io.open(payload_filepath, 'r', encoding='utf-8')
         data = f.read()
         return client.post(request_body=data)
 

--- a/sendgrid/helpers/mail/asm.py
+++ b/sendgrid/helpers/mail/asm.py
@@ -13,10 +13,10 @@ class ASM(object):
         self._groups_to_display = None
 
         if group_id is not None:
-            self._group_id = group_id
+            self.group_id = group_id
 
         if groups_to_display is not None:
-            self._groups_to_display = groups_to_display
+            self.groups_to_display = groups_to_display
 
     @property
     def group_id(self):

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 import sys
 import os
-import io
+from io import open
 from setuptools import setup, find_packages
 
 __version__ = None
@@ -9,7 +9,7 @@ with open('sendgrid/version.py') as f:
 
 long_description = 'Please see our GitHub README'
 if os.path.exists('README.txt'):
-    long_description = io.open('README.txt', 'r', encoding='utf-8').read()
+    long_description = open('README.txt', 'r', encoding='utf-8').read()
 
 
 def getRequires():

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import io
 from setuptools import setup, find_packages
 
 __version__ = None
@@ -8,7 +9,7 @@ with open('sendgrid/version.py') as f:
 
 long_description = 'Please see our GitHub README'
 if os.path.exists('README.txt'):
-    long_description = open('README.txt').read()
+    long_description = io.open('README.txt', 'r', encoding='utf-8').read()
 
 
 def getRequires():


### PR DESCRIPTION
When opening text files in few places, the code relies on system default encoding being set to UTF-8.

This is safe enough in general, but there are certain corner cases like #379, where default one is e.g. ASCII (for whatever reason).

The pull request changes code to use UTF-8 encoding explicitly, without relying on the system defaults.

EDIT: There is another commit fixing a unit test (`test_asm_display_group_limit`), since that was failing the build, coming from master rebase. 

EDIT2: The "reduced" code coverage is because of added import statements - so this is a false positive in fact.