### PR TITLE
Test to check year in LICENSE.txt

### DIFF
--- a/test/test_sendgrid.py
+++ b/test/test_sendgrid.py
@@ -2356,7 +2356,7 @@ class UnitTests(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
 
     def test_license_year(self):
-        LICENSE_FILE = 'license.txt'
+        LICENSE_FILE = 'LICENSE.txt'
         with open(LICENSE_FILE, 'r') as f:
             copyright_line = f.readline().rstrip()
         self.assertEqual('Copyright (c) 2012-%s SendGrid, Inc.' % datetime.datetime.now().year, copyright_line)

--- a/test/test_sendgrid.py
+++ b/test/test_sendgrid.py
@@ -9,6 +9,7 @@ import os
 import subprocess
 import sys
 import time
+import datetime
 
 host = "http://localhost:4010"
 
@@ -2353,6 +2354,12 @@ class UnitTests(unittest.TestCase):
         response = self.sg.client.whitelabel.links._(link_id).subuser.post(
             request_body=data, request_headers=headers)
         self.assertEqual(response.status_code, 200)
+
+    def test_license_year(self):
+        LICENSE_FILE = 'license.txt'
+        with open(LICENSE_FILE, 'r') as f:
+            copyright_line = f.readline().rstrip()
+        self.assertEqual('Copyright (c) 2012-%s SendGrid, Inc.' % datetime.datetime.now().year, copyright_line)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 
Fixes #474 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Added a test to ensure license year is current
- Test currently fails because MASTER has 2012-2016, which has been rectified by #477 

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
