### PR TITLE
Fix typo in test_env

### DIFF
--- a/test/test_project.py
+++ b/test/test_project.py
@@ -17,7 +17,7 @@ class ProjectTests(unittest.TestCase):
 
     # ./.env_sample
     def test_env(self):
-        self.assertTrue(os.path.isfile('./env_sample'))
+        self.assertTrue(os.path.isfile('./.env_sample'))
 
     # ./.gitignore
     def test_gitignore(self):


### PR DESCRIPTION
This PR fixes the `test_env` test. 
The project uses `.env_sample` (with a dot) and this seems to be the name of the file expected from both the comment above the test and the readme.
