### PR TITLE
wrong usage of variable

### DIFF
--- a/examples/helpers/mail/mail_example.py
+++ b/examples/helpers/mail/mail_example.py
@@ -24,25 +24,25 @@ def build_personalization(personalization):
     """Build personalization mock instance from a mock dict"""
     mock_personalization = Personalization()
     for to_addr in personalization['to_list']:
-        personalization.add_to(to_addr)
+        mock_personalization.add_to(to_addr)
 
     for cc_addr in personalization['cc_list']:
-        personalization.add_to(cc_addr)
+        mock_personalization.add_to(cc_addr)
 
     for bcc_addr in personalization['bcc_list']:
-        personalization.add_bc(bcc_addr)
+        mock_personalization.add_bc(bcc_addr)
 
     for header in personalization['headers']:
-        personalization.add_header(header)
+        mock_personalization.add_header(header)
 
     for substitution in personalization['substitutions']:
-        personalization.add_substitution(substitution)
+        mock_personalization.add_substitution(substitution)
 
     for arg in personalization['custom_args']:
-        personalization.add_custom_arg(arg)
+        mock_personalization.add_custom_arg(arg)
 
-    personalization.subject = personalization['subject']
-    personalization.send_at = personalization['send_at']
+    mock_personalization.subject = personalization['subject']
+    mock_personalization.send_at = personalization['send_at']
     return mock_personalization
 
 


### PR DESCRIPTION
build_personalization function definition
personalization variable was used instead of mock_personalization

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
- 
- 

If you have questions, please send an email to [Sendgrid](mailto:dx@sendgrid.com), or file a Github Issue in this repository.
