### PR TITLE
Fix `Personalization.substitutions` setter

### DIFF
--- a/sendgrid/helpers/mail/personalization.py
+++ b/sendgrid/helpers/mail/personalization.py
@@ -116,7 +116,7 @@ class Personalization(object):
 
     @substitutions.setter
     def substitutions(self, value):
-        self.substitutions = value
+        self._substitutions = value
 
     def add_substitution(self, substitution):
         """Add a new Substitution to this Personalization.

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -558,3 +558,7 @@ class UnitTests(unittest.TestCase):
             tracking_settings.get(),
             {'click_tracking': {'enable': False, 'enable_text': False}}
         )
+
+    def test_directly_setting_substitutions(self):
+        personalization = Personalization()
+        personalization.substitutions = [{'a': 0}]


### PR DESCRIPTION
Trying to set `substitutions` directly rather than with `add_substitution` was causing an infinite regress

# Fixes #582

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- the setter for `Personalization.substitutions` was incorrectly referencing `self.subtitutions` rather than `self._substitutions`
- I added a very simple testcase.
