### PR TITLE
Issue #587 Change type of category in Mail.add_category from string to Category

### DIFF
--- a/sendgrid/helpers/mail/mail.py
+++ b/sendgrid/helpers/mail/mail.py
@@ -8,10 +8,10 @@ class Mail(object):
 
     Use get() to get the request body.
     """
-    def __init__(self, 
-                 from_email=None, 
-                 subject=None, 
-                 to_email=None, 
+    def __init__(self,
+                 from_email=None,
+                 subject=None,
+                 to_email=None,
                  content=None):
         """Create a Mail object.
 
@@ -73,7 +73,7 @@ class Mail(object):
 
         if self.from_email is not None:
             mail["from"] = self.from_email.get()
-  
+
         if self.subject is not None:
             mail["subject"] = self.subject
 
@@ -306,7 +306,7 @@ class Mail(object):
         """
         if self._contents is None:
             self._contents = []
-        
+
         # Text content should be before HTML content
         if content._type == "text/plain":
             self._contents.insert(0, content)
@@ -376,9 +376,9 @@ class Mail(object):
         return self._categories
 
     def add_category(self, category):
-        """Add a Category to this Mail.  Must be less than 255 characters.
+        """Add a Category to this Mail.
 
-        :type category: string
+        :type category: Category
         """
         self._categories.append(category)
 


### PR DESCRIPTION
# Fixes # 
#587

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Change type of category in Mail.add_category from string to Category to prevent warning from some editors
