### PR TITLE
Fix helper mail_example redirection link

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ pip install sendgrid
 
 ## Hello Email
 
-The following is the minimum needed code to send an email with the [/mail/send Helper](https://github.com/sendgrid/sendgrid-python/tree/master/sendgrid/helpers/mail) ([here](https://github.com/sendgrid/sendgrid-python/blob/master/examples/helpers/mail/mail_example.py#L20) is a full example):
+The following is the minimum needed code to send an email with the [/mail/send Helper](https://github.com/sendgrid/sendgrid-python/tree/master/sendgrid/helpers/mail) ([here](https://github.com/sendgrid/sendgrid-python/blob/master/examples/helpers/mail_example.py) is a full example):
 
 ### With Mail Helper Class
 


### PR DESCRIPTION
Fixes #635 
Closes #636 

Redirection link of the helper's mail_example.py file

### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Fixes the broken example url path in the mail helper README.
- Closes PR #636 which does not redirect the changed url path to the helper's example file.
