### PR TITLE
master: Use raw-string notation for regex to avoid invalid escape sequence

### DIFF
--- a/sendgrid/helpers/mail/validators.py
+++ b/sendgrid/helpers/mail/validators.py
@@ -24,7 +24,7 @@ class ValidateAPIKey(object):
                 self.regexes.add(re.compile(regex_string))
 
         if use_default:
-            default_regex_string = 'SG\.[0-9a-zA-Z]+\.[0-9a-zA-Z]+'
+            default_regex_string = r'SG\.[0-9a-zA-Z]+\.[0-9a-zA-Z]+'
             self.regexes.add(re.compile(default_regex_string))
 
 


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.


Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->


### Checklist
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them.
- [x] I updated my branch with the master branch.
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [n/a] I have added necessary documentation about the functionality in the appropriate .md file
- [n/a] I have added in line documentation to the code I modified

### Short description of what this PR does:

- Use raw-string notation for regex to avoid invalid escape sequence

From the [`re` docs](https://docs.python.org/2/library/re.html#module-re):

> Regular expressions use the backslash character (`'\'`) to indicate special forms or to allow special characters to be used without invoking their special meaning. This collides with Python’s usage of the same character for the same purpose in string literals; for example, to match a literal backslash, one might have to write `'\\\\'` as the pattern string, because the regular expression must be `\\`, and each backslash must be expressed as `\\` inside a regular Python string literal.
>
> The solution is to use Python’s raw string notation for regular expression patterns; backslashes are not handled in any special way in a string literal prefixed with `'r'`. So `r"\n"` is a two-character string containing `'\'` and `'n'`, while `"\n"` is a one-character string containing a newline. Usually patterns will be expressed in Python code using this raw string notation.


#### Before

```console
$ pycodestyle | grep W605
./sendgrid/helpers/mail/validators.py:27:16: W605 invalid escape sequence '\.'
./sendgrid/helpers/mail/validators.py:27:30: W605 invalid escape sequence '\.'
$
```

#### After

```console
$ pycodestyle | grep W605
```

Once merged, the exception from https://github.com/sendgrid/sendgrid-python/pull/654 should be removed:

https://github.com/sendgrid/sendgrid-python/pull/654/files#diff-354f30a63fb0907d4ad57269548329e3R35
