### PR TITLE
Fixed a broken link for use cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,7 +225,7 @@ Removed the trailing white spaces. Big thanks to [Siddaram Halli](https://github
 ## [3.2.2] - 2016-08-23 ##
 ### Added
 - Table of Contents in the README
-- Added a [USE_CASES.md](https://github.com/sendgrid/sendgrid-python/blob/master/USE_CASES.md) section, with the first use case example for transactional templates
+- Added a [USE_CASES.md](https://github.com/sendgrid/sendgrid-python/tree/master/use_cases) section, with the first use case example for transactional templates
 
 ## [3.2.1] - 2016-08-17 ##
 ### Fixed


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes 

### Checklist
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guide] and my PR follows them.
- [ ] I updated my branch with the master branch.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [#] I have added necessary documentation about the functionality in the appropriate .md file
- [ ] I have added in line documentation to the code I modified

### Short description of what this PR does:
The below USE_CASES link under Changelog.md was broken, fixed the same.

Error: https://github.com/sendgrid/sendgrid-python/blob/master/USE_CASES.md on line 228 is unreachable.

Updated Link
https://github.com/sendgrid/sendgrid-python/tree/master/use_cases

If you have questions, please send an email to [SendGrid](mailto:dx@sendgrid.com), or file a GitHub Issue in this repository.