### PR TITLE
Fixed broken link for Use cases on CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,7 +218,7 @@ Removed the trailing white spaces. Big thanks to [Siddaram Halli](https://github
 ## [3.2.2] - 2016-08-23 ##
 ### Added
 - Table of Contents in the README
-- Added a [USE_CASES.md](https://github.com/sendgrid/sendgrid-python/blob/master/USE_CASES.md) section, with the first use case example for transactional templates
+- Added a [USE_CASES.md](https://github.com/sendgrid/sendgrid-python/tree/v4/use_cases) section, with the first use case example for transactional templates
 
 ## [3.2.1] - 2016-08-17 ##
 ### Fixed


### PR DESCRIPTION
### Short description of what this PR does:
### Short description of what this PR does:
The below USE_CASES link under Changelog.md for v4 branch was broken, fixed the same.
Error: https://github.com/sendgrid/sendgrid-python/blob/master/USE_CASES.md on line 221 is unreachable.

Updated Link
https://github.com/sendgrid/sendgrid-python/tree/v4/use_cases

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines given above, then fill out the blanks below.

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes # 

### Checklist
- [ ] I have added necessary documentation about the functionality in the appropriate change.md file