### PR TITLE
Update mail.py for attachment example.

### DIFF
--- a/examples/mail/mail.py
+++ b/examples/mail/mail.py
@@ -46,7 +46,7 @@ data = {
             "disposition": "inline",
             "filename": "file1.jpg",
             "name": "file1",
-            "type": "jpg"
+            "type": "application/pdf"
         }
     ],
     "batch_id": "[YOUR BATCH ID GOES HERE]",


### PR DESCRIPTION
Attachment example doesn't have the valid MIME type for PDF. The repo says PDF but should be application/pdf. Our helpers have the correct MIME type in their Type param, https://github.com/sendgrid/sendgrid-python/blob/master/examples/helpers/mail_example.py#L88 .

<!--
We appreciate the effort for this pull request, but before that, please make sure you read the [contribution guidelines](https://github.com/sendgrid/sendgrid-python/blob/v4/CONTRIBUTING.md), and then fill out the blanks below.

**All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g. 
Fixes #1
Closes #2
-->
# Fixes #X

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guide] and my PR follows them
- [x] I updated my branch with the master branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation about the functionality in the appropriate .md file
- [x] I have added in line documentation to the code I modified

### Short description of what this PR does:
- Updates JSON example to have matching example with Helper library and add valid MIME type for attachments. 

If you have questions, please send an email to [Twilio SendGrid](mailto:dx@sendgrid.com), or file a GitHub Issue in this repository.
