### PR TITLE
fix: type validation on to_emails parameter on mail object

### DIFF
--- a/sendgrid/helpers/mail/mail.py
+++ b/sendgrid/helpers/mail/mail.py
@@ -37,7 +37,7 @@ class Mail(object):
         :param subject: The subject of the email
         :type subject: Subject, optional
         :param to_emails: The email address of the recipient
-        :type to_emails: To, str, tuple, list(string), list(tuple),
+        :type to_emails: To, str, tuple, list(str), list(tuple),
                          list(To), optional
         :param plain_text_content: The plain text body of the email
         :type plain_text_content: string, optional

--- a/sendgrid/helpers/mail/mail.py
+++ b/sendgrid/helpers/mail/mail.py
@@ -37,7 +37,8 @@ class Mail(object):
         :param subject: The subject of the email
         :type subject: Subject, optional
         :param to_emails: The email address of the recipient
-        :type to_emails: To, tuple, optional
+        :type to_emails: To, str, tuple, list(string), list(tuple),
+                         list(To), optional
         :param plain_text_content: The plain text body of the email
         :type plain_text_content: string, optional
         :param html_content: The html body of the email
@@ -239,7 +240,7 @@ class Mail(object):
         """Adds a To object to the Personalization object
 
         :param to_email: A To object
-        :type to_email: To, str, tuple
+        :type to_email: To, str, tuple, list(str), list(tuple), list(To)
         :param global_substitutions: A dict of substitutions for all recipients
         :type global_substitutions: dict
         :param is_multiple: Create a new personalization for each recipient
@@ -253,8 +254,12 @@ class Mail(object):
             for email in to_email:
                 if isinstance(email, str):
                     email = To(email, None)
-                if isinstance(email, tuple):
+                elif isinstance(email, tuple):
                     email = To(email[0], email[1])
+                elif not isinstance(email, To):
+                    raise ValueError(
+                        'Please use a tuple, To, or a str for a to_email list.'
+                    )
                 self._set_emails(email, global_substitutions, is_multiple, p)
         else:
             if isinstance(to_email, str):

--- a/test/test_mail_helpers.py
+++ b/test/test_mail_helpers.py
@@ -284,6 +284,25 @@ class UnitTests(unittest.TestCase):
             }''')
         )
 
+    def test_value_error_is_thrown_on_to_emails_set_to_list_of_lists(self):
+        from sendgrid.helpers.mail import (Mail, From, Subject,
+                                           PlainTextContent, HtmlContent)
+        self.maxDiff = None
+        to_emails = [
+            ['test+to0@example.com', 'Example To Name 0'],
+            ['test+to1@example.com', 'Example To Name 1']
+        ]
+
+        with self.assertRaises(ValueError):
+            Mail(
+                from_email=From('test+from@example.com', 'Example From Name'),
+                to_emails=to_emails,
+                subject=Subject('Sending with SendGrid is Fun'),
+                plain_text_content=PlainTextContent(
+                    'and easy to do anywhere, even with Python'),
+                html_content=HtmlContent(
+                    '<strong>and easy to do anywhere, even with Python</strong>'))
+
     def test_dynamic_template_data(self):
         self.maxDiff = None
 

--- a/test/test_mail_helpers.py
+++ b/test/test_mail_helpers.py
@@ -284,9 +284,8 @@ class UnitTests(unittest.TestCase):
             }''')
         )
 
-    def test_value_error_is_thrown_on_to_emails_set_to_list_of_lists(self):
-        from sendgrid.helpers.mail import (Mail, From, Subject,
-                                           PlainTextContent, HtmlContent)
+    def test_value_error_is_raised_on_to_emails_set_to_list_of_lists(self):
+        from sendgrid.helpers.mail import (PlainTextContent, HtmlContent)
         self.maxDiff = None
         to_emails = [
             ['test+to0@example.com', 'Example To Name 0'],
@@ -302,6 +301,77 @@ class UnitTests(unittest.TestCase):
                     'and easy to do anywhere, even with Python'),
                 html_content=HtmlContent(
                     '<strong>and easy to do anywhere, even with Python</strong>'))
+
+    def test_error_is_not_raised_on_to_emails_set_to_list_of_tuples(self):
+        from sendgrid.helpers.mail import (PlainTextContent, HtmlContent)
+        self.maxDiff = None
+        to_emails = [
+            ('test+to0@example.com', 'Example To Name 0'),
+            ('test+to1@example.com', 'Example To Name 1')
+        ]
+
+        try:
+            Mail(
+                from_email=From('test+from@example.com', 'Example From Name'),
+                to_emails=to_emails,
+                subject=Subject('Sending with SendGrid is Fun'),
+                plain_text_content=PlainTextContent(
+                    'and easy to do anywhere, even with Python'),
+                html_content=HtmlContent(
+                    '<strong>and easy to do anywhere, even with Python</strong>'))
+        except:
+            self.fail('Mail() raised an error on list of tuples')
+
+    def test_error_is_not_raised_on_to_emails_set_to_list_of_strs(self):
+        from sendgrid.helpers.mail import (PlainTextContent, HtmlContent)
+        self.maxDiff = None
+        to_emails = ['test+to0@example.com', 'test+to1@example.com']
+
+        try:
+            Mail(
+                from_email=From('test+from@example.com', 'Example From Name'),
+                to_emails=to_emails,
+                subject=Subject('Sending with SendGrid is Fun'),
+                plain_text_content=PlainTextContent(
+                    'and easy to do anywhere, even with Python'),
+                html_content=HtmlContent(
+                    '<strong>and easy to do anywhere, even with Python</strong>'))
+        except:
+            self.fail('Mail() raised an error on list of strings')
+
+    def test_error_is_not_raised_on_to_emails_set_to_a_str(self):
+        from sendgrid.helpers.mail import (PlainTextContent, HtmlContent)
+        self.maxDiff = None
+        to_emails = 'test+to0@example.com'
+
+        try:
+            Mail(
+                from_email=From('test+from@example.com', 'Example From Name'),
+                to_emails=to_emails,
+                subject=Subject('Sending with SendGrid is Fun'),
+                plain_text_content=PlainTextContent(
+                    'and easy to do anywhere, even with Python'),
+                html_content=HtmlContent(
+                    '<strong>and easy to do anywhere, even with Python</strong>'))
+        except:
+            self.fail('Mail() raised an error on a string')
+
+    def test_error_is_not_raised_on_to_emails_set_to_a_tuple(self):
+        from sendgrid.helpers.mail import (PlainTextContent, HtmlContent)
+        self.maxDiff = None
+        to_emails = ('test+to0@example.com', 'Example To Name 0')
+
+        try:
+            Mail(
+                from_email=From('test+from@example.com', 'Example From Name'),
+                to_emails=to_emails,
+                subject=Subject('Sending with SendGrid is Fun'),
+                plain_text_content=PlainTextContent(
+                    'and easy to do anywhere, even with Python'),
+                html_content=HtmlContent(
+                    '<strong>and easy to do anywhere, even with Python</strong>'))
+        except:
+            self.fail('Mail() raised an error on a tuple of strings')
 
     def test_dynamic_template_data(self):
         self.maxDiff = None


### PR DESCRIPTION
Fixes https://github.com/sendgrid/sendgrid-python/issues/778

Validated values at runtime for a clearer error message for when someone sets `to_emails` to a list of lists