### PR TITLE
docs: Sending HTML email example is broken

### DIFF
--- a/use_cases/sending_html_content.md
+++ b/use_cases/sending_html_content.md
@@ -42,7 +42,6 @@ html_content = HtmlContent(html_text)
 soup = BeautifulSoup(html_text)
 plain_text = soup.get_text()
 plain_text_content = Content("text/plain", plain_text)
-mail.add_content(plain_content)
 
 message = Mail(from_email, to_email, subject, plain_text_content, html_content)
 

--- a/use_cases/sending_html_content.md
+++ b/use_cases/sending_html_content.md
@@ -35,7 +35,7 @@ html_text = """
 
 sendgrid_client = SendGridAPIClient(api_key=os.environ.get('SENDGRID_API_KEY'))
 from_email = From("from_email@exmaple.com")
-to_email = Email("to_email@example.com")
+to_email = To("to_email@example.com")
 subject = Subject("Test Subject")
 html_content = HtmlContent(html_text)
 


### PR DESCRIPTION
# Fixes #

The code sample in `sendgrid-python/blob/main/use_cases/sending_html_content.md` were broken. There were two problems. One undefined variable(`mail`) and one runtime error (`ValueError: Please use a To, Cc or Bcc object.`).

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x ] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x ] I have titled the PR appropriately
- [x ] I have updated my branch with the main branch
- [x ] I have added tests that prove my fix is effective or that my feature works
- [x ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
