### PR TITLE
fix: replace names in BatchId docstrings

### DIFF
--- a/sendgrid/helpers/mail/batch_id.py
+++ b/sendgrid/helpers/mail/batch_id.py
@@ -18,7 +18,7 @@ class BatchId(object):
 
     @property
     def batch_id(self):
-        """A unix timestamp.
+        """The batch ID.
 
         :rtype: string
         """
@@ -26,7 +26,7 @@ class BatchId(object):
 
     @batch_id.setter
     def batch_id(self, value):
-        """A unix timestamp.
+        """The batch ID.
 
         :param value: Batch Id
         :type value: string
@@ -42,7 +42,7 @@ class BatchId(object):
 
     def get(self):
         """
-        Get a JSON-ready representation of this SendAt object.
+        Get a JSON-ready representation of this BatchId object.
 
         :returns: The BatchId, ready for use in a request body.
         :rtype: string


### PR DESCRIPTION
Fixes names in docstrings referring to SendAt object methods. As is, the docstrings are confusing and/or distracting.


### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
