### PR TITLE
feat: add reply_to to helpers.Mail

### DIFF
--- a/sendgrid/helpers/mail/mail.py
+++ b/sendgrid/helpers/mail/mail.py
@@ -24,6 +24,7 @@ class Mail(object):
             self,
             from_email=None,
             to_emails=None,
+            reply_to=None,
             subject=None,
             plain_text_content=None,
             html_content=None,
@@ -40,6 +41,8 @@ class Mail(object):
         :param to_emails: The email address of the recipient
         :type to_emails: To, str, tuple, list(str), list(tuple),
                          list(To), optional
+        :param reply_to: The email address to reply to
+        :type reply_to: ReplyTo, tuple, optional
         :param plain_text_content: The plain text body of the email
         :type plain_text_content: string, optional
         :param html_content: The html body of the email
@@ -78,6 +81,10 @@ class Mail(object):
             self.add_content(amp_html_content, MimeType.amp)
         if html_content is not None:
             self.add_content(html_content, MimeType.html)
+
+        # Optional
+        if reply_to is not None:
+            self.reply_to = reply_to
 
     def __str__(self):
         """A JSON-ready string representation of this Mail object.

--- a/test/test_mail_helpers.py
+++ b/test/test_mail_helpers.py
@@ -100,6 +100,7 @@ class UnitTests(unittest.TestCase):
         message = Mail(
             from_email=From('test+from@example.com', 'Example From Name'),
             to_emails=To('test+to@example.com', 'Example To Name'),
+            reply_to=ReplyTo('test+reply_to@example.com', 'Example Reply To Name'),
             subject=Subject('Sending with SendGrid is Fun'),
             plain_text_content=PlainTextContent(
                 'and easy to do anywhere, even with Python'),
@@ -122,6 +123,10 @@ class UnitTests(unittest.TestCase):
                 "from": {
                     "email": "test+from@example.com",
                     "name": "Example From Name"
+                },
+                "reply_to": {
+                    "email": "test+reply_to@example.com",
+                    "name": "Example Reply To Name"
                 },
                 "personalizations": [
                     {

--- a/test/test_mail_helpers.py
+++ b/test/test_mail_helpers.py
@@ -94,7 +94,7 @@ class UnitTests(unittest.TestCase):
 
     # Send a Single Email to a Single Recipient
     def test_single_email_to_a_single_recipient(self):
-        from sendgrid.helpers.mail import (Mail, From, To, Subject,
+        from sendgrid.helpers.mail import (Mail, From, To, ReplyTo, Subject,
                                            PlainTextContent, HtmlContent)
         self.maxDiff = None
         message = Mail(

--- a/use_cases/send_a_single_email_to_a_single_recipient.md
+++ b/use_cases/send_a_single_email_to_a_single_recipient.md
@@ -6,6 +6,7 @@ from sendgrid.helpers.mail import Mail
 message = Mail(
     from_email='from_email@example.com',
     to_emails='to@example.com',
+    reply_to='reply_to@example.com',
     subject='Sending with Twilio SendGrid is Fun',
     html_content='<strong>and easy to do anywhere, even with Python</strong>')
 try:


### PR DESCRIPTION

<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

-->

# Fixes #

Add the `reply_to` keyword argument to `helpers.mail.Mail`.

Otherwise, we must create the Mail and then set the reply_to with
its setter (and we have to dig the repository to find out).

I didn't run the tests locally.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [X] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [X] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [X] I have titled the PR appropriately
- [X] I have updated my branch with the main branch
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added the necessary documentation about the functionality in the appropriate .md file
- [X] I have added inline documentation to the code I modified


