### PR TITLE
chore: get rid of reply_to in mail helper

### DIFF
--- a/sendgrid/helpers/mail/mail.py
+++ b/sendgrid/helpers/mail/mail.py
@@ -24,7 +24,6 @@ class Mail(object):
             self,
             from_email=None,
             to_emails=None,
-            reply_to=None,
             subject=None,
             plain_text_content=None,
             html_content=None,
@@ -41,8 +40,6 @@ class Mail(object):
         :param to_emails: The email address of the recipient
         :type to_emails: To, str, tuple, list(str), list(tuple),
                          list(To), optional
-        :param reply_to: The email address to reply to
-        :type reply_to: ReplyTo, tuple, optional
         :param plain_text_content: The plain text body of the email
         :type plain_text_content: string, optional
         :param html_content: The html body of the email
@@ -81,10 +78,6 @@ class Mail(object):
             self.add_content(amp_html_content, MimeType.amp)
         if html_content is not None:
             self.add_content(html_content, MimeType.html)
-
-        # Optional
-        if reply_to is not None:
-            self.reply_to = reply_to
 
     def __str__(self):
         """A JSON-ready string representation of this Mail object.

--- a/test/test_mail_helpers.py
+++ b/test/test_mail_helpers.py
@@ -94,13 +94,12 @@ class UnitTests(unittest.TestCase):
 
     # Send a Single Email to a Single Recipient
     def test_single_email_to_a_single_recipient(self):
-        from sendgrid.helpers.mail import (Mail, From, To, ReplyTo, Subject,
+        from sendgrid.helpers.mail import (Mail, From, To, Subject,
                                            PlainTextContent, HtmlContent)
         self.maxDiff = None
         message = Mail(
             from_email=From('test+from@example.com', 'Example From Name'),
             to_emails=To('test+to@example.com', 'Example To Name'),
-            reply_to=ReplyTo('test+reply_to@example.com', 'Example Reply To Name'),
             subject=Subject('Sending with SendGrid is Fun'),
             plain_text_content=PlainTextContent(
                 'and easy to do anywhere, even with Python'),
@@ -123,10 +122,6 @@ class UnitTests(unittest.TestCase):
                 "from": {
                     "email": "test+from@example.com",
                     "name": "Example From Name"
-                },
-                "reply_to": {
-                    "email": "test+reply_to@example.com",
-                    "name": "Example Reply To Name"
                 },
                 "personalizations": [
                     {
@@ -660,7 +655,7 @@ class UnitTests(unittest.TestCase):
         p.add_email(to_email)
 
         self.assertEqual([to_email.get()], p.tos)
-    
+
     def test_personalization_add_email_filters_out_duplicate_to_emails_ignoring_case(self):
         self.maxDiff = None
 

--- a/use_cases/send_a_single_email_to_a_single_recipient.md
+++ b/use_cases/send_a_single_email_to_a_single_recipient.md
@@ -6,7 +6,6 @@ from sendgrid.helpers.mail import Mail
 message = Mail(
     from_email='from_email@example.com',
     to_emails='to@example.com',
-    reply_to='reply_to@example.com',
     subject='Sending with Twilio SendGrid is Fun',
     html_content='<strong>and easy to do anywhere, even with Python</strong>')
 try:


### PR DESCRIPTION
# Fixes #

Remove duplicated `reply_to` in the `mail` helper

Fixes #1001 
Revert #999
 