### PR TITLE
chore: Remove unused import from distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import io
 import os
-from distutils.file_util import copy_file
 from setuptools import setup, find_packages
 
 


### PR DESCRIPTION
The import is unused and distutils is scheduled for removal in Python 3.12. So this can be safely removed.

```
python3.10             
Python 3.10.0b1 (default, May  6 2021, 02:44:57) [GCC 7.5.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from distutils.file_util import copy_file
<stdin>:1: DeprecationWarning: The distutils package is deprecated and slated for removal in Python 3.12. Use setuptools or check PEP 632 for potential alternatives
```

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [ ] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [ ] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [ ] I have titled the PR appropriately
- [ ] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com), or create a GitHub Issue in this repository.
