### PR TITLE
docs: Removing unused json import

### DIFF
--- a/use_cases/transactional_templates.md
+++ b/use_cases/transactional_templates.md
@@ -28,7 +28,6 @@ I hope you are having a great day in {{ city }} :)
 
 ```python
 import os
-import json
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
 
@@ -86,7 +85,6 @@ I hope you are having a great day in {{{ city }}} :)
 
 ```python
 import os
-import json
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import Mail
 


### PR DESCRIPTION
# Fixes #

In the transaction email template example the `json` import is unused.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified