### PR TITLE
feat: Add reply_to_list functionality

### DIFF
--- a/sendgrid/helpers/mail/mail.py
+++ b/sendgrid/helpers/mail/mail.py
@@ -716,12 +716,11 @@ class Mail(object):
                 if isinstance(reply, ReplyTo):
                     if not isinstance(reply.email, str):
                         raise ValueError('You must provide an email for each entry in a reply_to_list')
-                    reply = ReplyTo(reply.email, reply.name)
                 else:
                     raise ValueError(
                         'Please use a list of ReplyTos for a reply_to_list.'
                     )
-                self._reply_to_list = value
+            self._reply_to_list = value
 
     @property
     def contents(self):

--- a/sendgrid/helpers/mail/mail.py
+++ b/sendgrid/helpers/mail/mail.py
@@ -60,6 +60,7 @@ class Mail(object):
         self._ip_pool_name = None
         self._mail_settings = None
         self._reply_to = None
+        self._reply_to_list = None
         self._send_at = None
         self._subject = None
         self._template_id = None
@@ -696,6 +697,33 @@ class Mail(object):
         self._reply_to = value
 
     @property
+    def reply_to_list(self):
+        """A list of ReplyTo email addresses
+
+        :rtype: list(ReplyTo), tuple
+        """
+        return self._reply_to_list
+
+    @reply_to_list.setter
+    def reply_to_list(self, value):
+        """A list of ReplyTo email addresses
+
+        :param value: A list of ReplyTo email addresses
+        :type value: list(ReplyTo), tuple
+        """
+        if isinstance(value, list):
+            for reply in value:
+                if isinstance(reply, ReplyTo):
+                    if not isinstance(reply.email, str):
+                        raise ValueError('You must provide an email for each entry in a reply_to_list')
+                    reply = ReplyTo(reply.email, reply.name)
+                else:
+                    raise ValueError(
+                        'Please use a list of ReplyTos for a reply_to_list.'
+                    )
+                self._reply_to_list = value
+
+    @property
     def contents(self):
         """The contents of the email
 
@@ -981,6 +1009,7 @@ class Mail(object):
             'mail_settings': self._get_or_none(self.mail_settings),
             'tracking_settings': self._get_or_none(self.tracking_settings),
             'reply_to': self._get_or_none(self.reply_to),
+            'reply_to_list': [r.get() for r in self.reply_to_list or []],
         }
 
         return {key: value for key, value in mail.items()

--- a/test/unit/test_mail_helpers.py
+++ b/test/unit/test_mail_helpers.py
@@ -235,6 +235,58 @@ class UnitTests(unittest.TestCase):
             }''')
         )
 
+    def test_send_a_single_email_with_multiple_reply_to_addresses(self):
+        from sendgrid.helpers.mail import (Mail, From, ReplyTo, To, Subject,
+                                           PlainTextContent, HtmlContent)
+        self.maxDiff = None
+        message = Mail(
+            from_email=From('test+from@example.com', 'Example From Name'),
+            to_emails=To('test+to0@example.com', 'Example To Name'),
+            subject=Subject('Sending with SendGrid is Fun'),
+            plain_text_content=PlainTextContent('and easy to do anywhere, even with Python'),
+            html_content=HtmlContent('<strong>and easy to do anywhere, even with Python</strong>'))
+
+        message.reply_to_list = [ReplyTo(email = 'test+reply_to_1@example.com'), ReplyTo(email = 'test+reply_to_2@example.com')]
+
+        self.assertEqual(
+            message.get(),
+            json.loads(r'''{
+                "content": [
+                    {
+                        "type": "text/plain",
+                        "value": "and easy to do anywhere, even with Python"
+                    },
+                    {
+                        "type": "text/html",
+                        "value": "<strong>and easy to do anywhere, even with Python</strong>"
+                    }
+                ],
+                "from": {
+                    "email": "test+from@example.com",
+                    "name": "Example From Name"
+                },
+                "personalizations": [
+                    {
+                        "to": [
+                            {
+                                "email": "test+to0@example.com",
+                                "name": "Example To Name"
+                            }
+                        ]
+                    }
+                ],
+                "reply_to_list": [
+                    {
+                        "email": "test+reply_to_1@example.com"
+                    },
+                    {
+                        "email": "test+reply_to_2@example.com"
+                    }
+                ],
+                "subject": "Sending with SendGrid is Fun"
+            }''')
+        )
+
     def test_multiple_emails_to_multiple_recipients(self):
         from sendgrid.helpers.mail import (Mail, From, To, Subject,
                                            PlainTextContent, HtmlContent,
@@ -568,6 +620,44 @@ class UnitTests(unittest.TestCase):
                     'and easy to do anywhere, even with Python'),
                 html_content=HtmlContent(
                     '<strong>and easy to do anywhere, even with Python</strong>'))
+    
+    def test_value_error_is_raised_on_to_emails_set_to_reply_to_list_of_strs(self):
+        from sendgrid.helpers.mail import (PlainTextContent, HtmlContent)
+        self.maxDiff = None
+        to_emails = [
+            ('test+to0@example.com', 'Example To Name 0'),
+            ('test+to1@example.com', 'Example To Name 1')
+        ]
+    
+        mail = Mail(
+            from_email=From('test+from@example.com', 'Example From Name'),
+            to_emails=to_emails,
+            subject=Subject('Sending with SendGrid is Fun'),
+            plain_text_content=PlainTextContent(
+                'and easy to do anywhere, even with Python'),
+            html_content=HtmlContent(
+                '<strong>and easy to do anywhere, even with Python</strong>'))
+        with self.assertRaises(ValueError):
+            mail.reply_to_list = ['test+reply_to0@example.com', 'test+reply_to1@example.com']
+    
+    def test_value_error_is_raised_on_to_emails_set_to_reply_to_list_of_tuples(self):
+        from sendgrid.helpers.mail import (PlainTextContent, HtmlContent)
+        self.maxDiff = None
+        to_emails = [
+            ('test+to0@example.com', 'Example To Name 0'),
+            ('test+to1@example.com', 'Example To Name 1')
+        ]
+    
+        mail = Mail(
+            from_email=From('test+from@example.com', 'Example From Name'),
+            to_emails=to_emails,
+            subject=Subject('Sending with SendGrid is Fun'),
+            plain_text_content=PlainTextContent(
+                'and easy to do anywhere, even with Python'),
+            html_content=HtmlContent(
+                '<strong>and easy to do anywhere, even with Python</strong>'))
+        with self.assertRaises(ValueError):
+            mail.reply_to_list = [('test+reply_to@example.com', 'Test Name')]
 
     def test_error_is_not_raised_on_to_emails_set_to_list_of_tuples(self):
         from sendgrid.helpers.mail import (PlainTextContent, HtmlContent)

--- a/use_cases/send_a_single_email_with_multiple_reply_to_addresses.md
+++ b/use_cases/send_a_single_email_with_multiple_reply_to_addresses.md
@@ -1,0 +1,29 @@
+```python
+import os
+from sendgrid import SendGridAPIClient
+from sendgrid.helpers.mail import Mail
+
+message = Mail(
+    from_email='from_email@example.com',
+    to_emails='to@example.com',
+    subject='Sending with Twilio SendGrid is Fun',
+    html_content='<strong>and easy to do anywhere, even with Python</strong>')
+message.reply_to_list = [
+    ReplyTo(
+        email='reply-to-1@example.com',
+        name="Reply To Name 1",
+    ),
+    ReplyTo(
+        email='reply-to-2@example.com',
+        name="Reply To Name 2",
+    )
+]
+try:
+    sendgrid_client = SendGridAPIClient(os.environ.get('SENDGRID_API_KEY'))
+    response = sendgrid_client.send(message)
+    print(response.status_code)
+    print(response.body)
+    print(response.headers)
+except Exception as e:
+    print(e)
+```


### PR DESCRIPTION
`reply_to_list` exists in the sendgrid API v3, but it has never been implemented for the python api.

I added tests and a use case, but I didn't see any other docs. But this property already exists in the [official docs](https://docs.sendgrid.com/api-reference/mail-send/mail-send#multiple-reply-to-emails).

Also, I never code in python, so I may have made some mistakes here. Just kind of based this off of the existing code and some googling.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [-] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).