### PR TITLE
test: removing codedev test dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@
 
 
 
-|Tests Badge| |codecov| |Python Versions| |PyPI Version| |Docker Badge| |MIT licensed| |Twitter Follow| |GitHub contributors| |Open Source Helpers|
+|Tests Badge| |Python Versions| |PyPI Version| |Docker Badge| |MIT licensed| |Twitter Follow| |GitHub contributors| |Open Source Helpers|
 
 **This library allows you to quickly and easily use the Twilio SendGrid Web API v3 via Python.**
 
@@ -288,8 +288,6 @@ License
    :target: https://pypi.org/project/sendgrid/
 .. |PyPI Version| image:: https://img.shields.io/pypi/v/sendgrid.svg
    :target: https://pypi.org/project/sendgrid/
-.. |codecov| image:: https://img.shields.io/codecov/c/github/sendgrid/sendgrid-python/main.svg?style=flat-square&label=Codecov+Coverage
-   :target: https://codecov.io/gh/sendgrid/sendgrid-python
 .. |Docker Badge| image:: https://img.shields.io/docker/automated/sendgrid/sendgrid-python.svg
    :target: https://hub.docker.com/r/sendgrid/sendgrid-python/
 .. |MIT licensed| image:: https://img.shields.io/badge/license-MIT-blue.svg

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,7 +2,6 @@ pyyaml
 Flask==1.1.4
 six
 coverage
-codecov
 mock
 itsdangerous==1.1.0
 markupsafe==1.1.1


### PR DESCRIPTION
# Fixes #

Fix build by removing dead dependency.

Per the announcment:
https://about.codecov.io/blog/message-regarding-the-pypi-package/ coddev deprecated their pypi package on april 12, 2023 causing the build to break

We no longer are registered at codedev:
https://app.codecov.io/gh/sendgrid/sendgrid-python "This repo has been deactivated"

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).