### PR TITLE
feat: Multiple Webhook Support

### DIFF
--- a/examples/user/user.py
+++ b/examples/user/user.py
@@ -196,7 +196,8 @@ data = {
     "unsubscribe": True,
     "url": "url"
 }
-response = sg.client.user.webhooks.event.settings.patch(request_body=data)
+webhook_id = "some-webhook-uuid"
+response = sg.client.user.webhooks.event.settings._(webhook_id).patch(request_body=data)
 print(response.status_code)
 print(response.body)
 print(response.headers)
@@ -205,7 +206,8 @@ print(response.headers)
 # Retrieve Event Webhook settings #
 # GET /user/webhooks/event/settings #
 
-response = sg.client.user.webhooks.event.settings.get()
+webhook_id = "some-webhook-uuid"
+response = sg.client.user.webhooks.event.settings._(webhook_id).get()
 print(response.status_code)
 print(response.body)
 print(response.headers)
@@ -214,8 +216,10 @@ print(response.headers)
 # Test Event Notification Settings  #
 # POST /user/webhooks/event/test #
 
+webhook_id = "some-webhook-uuid"
 data = {
-    "url": "url"
+    "url": "url",
+    "id": webhook_id
 }
 response = sg.client.user.webhooks.event.test.post(request_body=data)
 print(response.status_code)

--- a/test/integ/test_sendgrid.py
+++ b/test/integ/test_sendgrid.py
@@ -1992,19 +1992,36 @@ class UnitTests(unittest.TestCase):
             "unsubscribe": True,
             "url": "url"
         }
+        webhook_id = "some-webhook-uuid"
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.webhooks.event.settings.patch(
+        response = self.sg.client.user.webhooks.event.settings._(webhook_id).patch(
             request_body=data, request_headers=headers)
+        self.assertEqual(response.status_code, 200)
+
+    # legacy webhook API only allowed for a single webhook. When no ID is provided,
+    # backwards compatiblity ensures we will get the oldest webhook back.
+    # Going forward, users should use settings._(webhook_id) in all calls.
+    def test_user_webhooks_event_settings_get_legacy_no_id(self):
+        headers = {'X-Mock': 200}
+        webhook_id = "some-webhook-uuid"
+        response = self.sg.client.user.webhooks.event.settings.get(
+            request_headers=headers)
+        repr(response)
         self.assertEqual(response.status_code, 200)
 
     def test_user_webhooks_event_settings_get(self):
         headers = {'X-Mock': 200}
-        response = self.sg.client.user.webhooks.event.settings.get(
+        webhook_id = "some-webhook-uuid"
+        self.assertTrue(False, "not true")
+        response = self.sg.client.user.webhooks.event.settings._(webhook_id).get(
             request_headers=headers)
+        self.assertEqual(repr(response), "I got a response")
+
         self.assertEqual(response.status_code, 200)
 
     def test_user_webhooks_event_test_post(self):
         data = {
+            "id": "some-webhook-id",
             "url": "url"
         }
         headers = {'X-Mock': 204}


### PR DESCRIPTION
SendGrid now allows for multiple webhooks and this PR pulls in the non-breaking API changes to support it.

Webhook resources will now take an ID parameter to target specific webhooks. When a webhook resource is NOT used with an ID, the API falls back to legacy behavior assuming there is only one webhook, and this defaults to the oldest webhook available. Users should update their services to reference webhooks by ID.

- [ ] Prerequisite PR (internal): https://code.hq.twilio.com/twilio/sendgrid-oai/pull/47
- [ ] Read only docs repo updated (github.com/sendgrid/sendgrid-oai) 

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).