### PR TITLE
docs: Remove mention of filing issues, since they are disabled in the repository

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -2,8 +2,6 @@ If you have an issue logging into your Twilio SendGrid account, please read this
 
 If you have a non-library Twilio SendGrid issue, please contact our [support team](https://support.sendgrid.com).
 
-If you can't find a solution below, please open an [issue](https://github.com/sendgrid/sendgrid-python/issues).
-
 ## Table of Contents
 
 * [Environment Variables and Your Twilio SendGrid API Key](#environment)


### PR DESCRIPTION
The troubleshooting guide talks about filing issues and links to `/issues`, but this link redirects to `/pulls`, as this repository does not to have "issues" functionality enabled (or at least it is not visible to me):

![image](https://github.com/sendgrid/sendgrid-python/assets/6729309/ae1750da-582b-4130-89ec-3d340cb425d5)

This PR removes the line about filing issues, in order to avoid confusion.

If there is a better text to put in its place, let me know or edit the PR directly.