### PR TITLE
chore: Relax werkzeug version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,11 @@ def getRequires():
         'ecdsa>=0.19.1,<1',
         "werkzeug>=0.11.15,<1.0.0 ; python_version < '3.0'",
         "werkzeug>=0.15.0,<2.0.0 ; python_version >= '3.0' and python_version < '3.6'",
-        "werkzeug>=2.0.0,<3.0.0 ; python_version >= '3.6' and python_version < '3.11'",
-        "werkzeug>=3.0.0 ; python_version >= '3.11'"
+        "werkzeug>=0.15.0,<2.3.0 ; python_version >= '3.0' and python_version < '3.7'",
+        "werkzeug>=0.16.0,<3.1.0 ; python_version >= '3.0' and python_version < '3.8'",
+        "werkzeug>=1.0.0 ; python_version >= '3.9'",
+        "werkzeug>=2.2.0 ; python_version >= '3.11'",
+        "werkzeug>=2.3.5 ; python_version >= '3.12'"
     ]
     return deps
 


### PR DESCRIPTION
From werkzeug changelog:

version 2.3.5 added support for Python 3.12 https://github.com/pallets/werkzeug/blob/main/CHANGES.rst#version-235
version 2.2.0 added/fixed support for Python 3.11 https://github.com/pallets/werkzeug/blob/main/CHANGES.rst#version-220
version 2.3.0 dropped support for Python 3.7 https://github.com/pallets/werkzeug/blob/main/CHANGES.rst#version-230

I couldn't find entries for all versions in the changelog but this should better reflect the lower and upper binds