### PR TITLE
feat!: update supported versions to match security updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ We welcome direct contributions to the sendgrid-python code base. Thank you!
 
 #### Prerequisites
 
-- Python version 2.7, 3.5, 3.6, 3.7, or 3.8
+- Python version 3.8+
 - [python_http_client](https://github.com/sendgrid/python-http-client)
 - [cryptography](https://github.com/pyca/cryptography)
 - [pyenv](https://github.com/yyuu/pyenv)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: venv install test-install test test-integ test-docker clean nopyc
 
 venv: clean
-	@python --version || (echo "Python is not installed, please install Python 2 or Python 3"; exit 1);
+	@python --version || (echo "Python is not installed, please install Python 3"; exit 1);
 	pip install virtualenv
 	virtualenv --python=python venv
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please browse the rest of this README for further detail.
 
 ## Prerequisites
 
-- Python version 2.7+
+- Python version 3.8+
 - The SendGrid service, starting at the [free level](https://sendgrid.com/free?source=sendgrid-python)
 
 ## Setup Environment Variables

--- a/README.rst
+++ b/README.rst
@@ -43,7 +43,7 @@ Installation
 Prerequisites
 -------------
 
--  Python version 2.7 and 3.5+
+-  Python version 3.8+
 -  For email, you will need a Twilio SendGrid account, starting at the `free level`_
 -  For SMS messages, you will need a free `Twilio account`_
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -37,17 +37,6 @@ In the first case, SENDGRID_API_KEY is in reference to the name of the environme
 
 HTTP exceptions are defined in the [`python_http_client` package](https://github.com/sendgrid/python-http-client/blob/HEAD/python_http_client/exceptions.py).
 
-To read the error message returned by SendGrid's API in Python 2.X:
-
-```python
-from python_http_client.exceptions import HTTPError
-
-try:
-  response = sg.client.mail.send.post(request_body=mail.get())
-except HTTPError as e:
-    print e.to_dict
-```
-
 To read the error message returned by Twilio SendGrid's API in Python 3.X:
 
 ```python

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Flask==3.1.0
 PyYAML>=4.2b1
 python-http-client>=3.2.1
 six==1.17.0
-cryptography>=45.0.6
+cryptography>=44.0.1
 more-itertools==5.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,54 +1,46 @@
 import io
 import os
-from setuptools import setup, find_packages
 
+from setuptools import find_packages, setup
 
 __version__ = None
-with open('sendgrid/version.py') as f:
+with open("sendgrid/version.py") as f:
     exec(f.read())
+
 
 def getRequires():
     deps = [
-        'python_http_client>=3.2.1',
-        'cryptography>=45.0.6',
-        "werkzeug>=0.11.15,<1.0.0 ; python_version < '3.0'",
-        "werkzeug>=0.15.0,<2.0.0 ; python_version >= '3.0' and python_version < '3.7'",
-        "werkzeug>=0.15.0,<2.3.0 ; python_version >= '3.0' and python_version < '3.8'", # version 2.3.0 dropped support for Python 3.7
-        "werkzeug>=0.16.0,<3.1.0 ; python_version >= '3.0' and python_version < '3.9'", # version 3.1.0 dropped support for Python 3.8
-        "werkzeug>=1.0.0 ; python_version >= '3.9'",
-        "werkzeug>=2.2.0 ; python_version >= '3.11'",
-        "werkzeug>=2.3.5 ; python_version >= '3.12'"
+        "python_http_client>=3.2.1",
+        "cryptography>=44.0.1",
+        "werkzeug==3.0.6 ; python_version == '3.8'",  # version 3.1.0 dropped support for Python 3.8
+        "werkzeug>=3.0.6 ; python_version >= '3.9'",
     ]
     return deps
 
 
 dir_path = os.path.abspath(os.path.dirname(__file__))
-readme = io.open(os.path.join(dir_path, 'README.rst'), encoding='utf-8').read()
+readme = io.open(os.path.join(dir_path, "README.rst"), encoding="utf-8").read()
 
 setup(
-    name='sendgrid',
+    name="sendgrid",
     version=str(__version__),
-    author='Elmer Thomas, Yamil Asusta',
-    author_email='help@twilio.com',
-    url='https://github.com/sendgrid/sendgrid-python/',
+    author="Elmer Thomas, Yamil Asusta",
+    author_email="help@twilio.com",
+    url="https://github.com/sendgrid/sendgrid-python/",
     packages=find_packages(exclude=["temp*.py", "test"]),
     include_package_data=True,
-    license='MIT',
-    description='Twilio SendGrid library for Python',
+    license="MIT",
+    description="Twilio SendGrid library for Python",
     long_description=readme,
     install_requires=getRequires(),
-    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*',
+    python_requires=">=3.8",
     classifiers=[
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
-    ]
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36, py37, py38, py39, py310, py311, py312, py313
+envlist =  py38, py39, py310, py311, py312, py313
 
 [testenv]
 commands = coverage erase
@@ -13,32 +13,6 @@ commands = coverage erase
 deps = -rrequirements.txt
        coverage
 
-
-[testenv:py27]
-commands = {[testenv]commands}
-deps = {[testenv]deps}
-       mock
-basepython = python2.7
-
-[testenv:py34]
-commands = {[testenv]commands}
-deps = {[testenv]deps}
-basepython = python3.4
-
-[testenv:py35]
-commands = {[testenv]commands}
-deps = {[testenv]deps}
-basepython = python3.5
-
-[testenv:py36]
-commands = {[testenv]commands}
-deps = {[testenv]deps}
-basepython = python3.6
-
-[testenv:py37]
-commands = {[testenv]commands}
-deps = {[testenv]deps}
-basepython = python3.7
 
 [testenv:py38]
 commands = {[testenv]commands}

--- a/use_cases/aws.md
+++ b/use_cases/aws.md
@@ -9,7 +9,6 @@ The neat thing is that CodeStar provides all of this in a pre-configured package
 Once this tutorial is complete, you'll have a basic web service for sending email that can be invoked via a link to your newly created API endpoint.
 
 ### Prerequisites
-Python 2.7 and 3.4 or 3.5 are supported by the sendgrid Python library, however, I was able to utilize 3.6 with no issue.
 
 Before starting this tutorial, you will need to have access to an AWS account in which you are allowed to provision resources. This tutorial also assumes you've already created a Twilio SendGrid account with free-tier access. Finally, it is highly recommended you utilize [virtualenv](https://virtualenv.pypa.io/en/stable/).
 
@@ -77,7 +76,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: python3.6
+      Runtime: python3.9
       Role:
         Fn::ImportValue:
           !Join ['-', [!Ref 'ProjectId', !Ref 'AWS::Region', 'LambdaTrustRole']]

--- a/use_cases/legacy_templates.md
+++ b/use_cases/legacy_templates.md
@@ -40,12 +40,7 @@ I hope you are having a great day in -city- :)
 import sendgrid
 import os
 from sendgrid.helpers.mail import Email, Content, Substitution, Mail
-try:
-    # Python 3
-    import urllib.request as urllib
-except ImportError:
-    # Python 2
-    import urllib2 as urllib
+import urllib.request as urllib
 
 sg = sendgrid.SendGridAPIClient(os.environ.get('SENDGRID_API_KEY'))
 from_email = Email("test@example.com")
@@ -71,12 +66,7 @@ print(response.headers)
 ```python
 import sendgrid
 import os
-try:
-    # Python 3
-    import urllib.request as urllib
-except ImportError:
-    # Python 2
-    import urllib2 as urllib
+import urllib.request as urllib
 
 sg = sendgrid.SendGridAPIClient(os.environ.get('SENDGRID_API_KEY'))
 data = {

--- a/use_cases/sending_html_content.md
+++ b/use_cases/sending_html_content.md
@@ -9,12 +9,7 @@ Currently, we require both HTML and Plain Text content for improved deliverabili
 import os
 from sendgrid import SendGridAPIClient
 from sendgrid.helpers.mail import From, To, Subject, PlainTextContent, HtmlContent, Mail
-try:
-    # Python 3
-    import urllib.request as urllib
-except ImportError:
-    # Python 2
-    import urllib2 as urllib
+import urllib.request as urllib
 from bs4 import BeautifulSoup
 
 html_text = """


### PR DESCRIPTION
> [!IMPORTANT]
> Officially drops support for python <3.7 (was already not supported by this package) 

# Related ##

Related #1105 

Makes #1112 easier to implement

## Summary 

This PR updates the bounds of dependencies, in order to match recent security updates. 

This does mean that python 2.7 support is officially dropped. As well as python 3.7 and below. 
However, they **were dropped before this**. This PR just reflects that in the setup.py file.

## Cryptography bounds

With #1114, you are now bound by the requirements of that package. Cryptography dropped support for python 2 in v3.4: https://cryptography.io/en/latest/changelog/#v3-4

Python 3.7 is about to be dropped from Cryptography in the next release. But that doesn't matter because of `Werkzeug` (mind you, all of these old versions are way past their EOL)

I lowered the bound to `44.0.1`. This is the last known good version without _known_ security vulnerabilities. 

## Werkzeug

The last version that doesn't contain security vulnerabilities is `3.0.6`. This version does support python 3.8. And as such, if you want to capture security updates, python 3.8 is the lowest version you can support. 

In theory, you could support python 3.7 if you don't want to capture the Werkzeug security updates.

### Checklist
- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-python/blob/main/CONTRIBUTING.md) and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).

### What this PR is not

While this PR does make the docs reflect that <3.7 is not supported, this is not an upgrade to python 3. That can be done in a different PR. One that removes special imports for python 2.7. I don't want to waste my time doing that if you decide to revert things so you can support 2.7.