### PR TITLE
feat!: Add timeout parameter to SendGrid API clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,16 @@ print(response.body)
 print(response.headers)
 ```
 
+## Timeout
+
+By default, HTTP requests will time out after 30 seconds. You can change this by passing a `timeout` parameter (in seconds) when creating the client:
+
+```python
+sg = sendgrid.SendGridAPIClient(api_key=os.environ.get('SENDGRID_API_KEY'), timeout=60)
+```
+
+To disable the timeout, pass `None`.
+
 ## General v3 Web API Usage (With [Fluent Interface](https://sendgrid.com/blog/using-python-to-implement-a-fluent-interface-to-any-rest-api/))
 
 ```python

--- a/sendgrid/base_interface.py
+++ b/sendgrid/base_interface.py
@@ -1,9 +1,14 @@
+import socket
+import urllib.error
+
 import python_http_client
+
+from .helpers.mail.exceptions import SendGridTimeoutError
 
 region_host_dict = {'eu':'https://api.eu.sendgrid.com','global':'https://api.sendgrid.com'}
 
 class BaseInterface(object):
-    def __init__(self, auth, host, impersonate_subuser):
+    def __init__(self, auth, host, impersonate_subuser, timeout=30):
         """
         Construct the Twilio SendGrid v3 API object.
         Note that the underlying client is being set up during initialization,
@@ -20,6 +25,9 @@ class BaseInterface(object):
         :type impersonate_subuser: string
         :param host: base URL for API calls
         :type host: string
+        :param timeout: the timeout (in seconds) for HTTP requests.
+                        Defaults to 30. Set to None to disable.
+        :type timeout: int
         """
         from . import __version__
         self.auth = auth
@@ -27,11 +35,13 @@ class BaseInterface(object):
         self.version = __version__
         self.useragent = 'sendgrid/{};python'.format(self.version)
         self.host = host
+        self.timeout = timeout
 
         self.client = python_http_client.Client(
             host=self.host,
             request_headers=self._default_headers,
-            version=3)
+            version=3,
+            timeout=timeout)
 
     @property
     def _default_headers(self):
@@ -60,7 +70,13 @@ class BaseInterface(object):
         if not isinstance(message, dict):
             message = message.get()
 
-        return self.client.mail.send.post(request_body=message)
+        try:
+            return self.client.mail.send.post(request_body=message)
+        except urllib.error.URLError as e:
+            if isinstance(e.reason, socket.timeout):
+                raise SendGridTimeoutError(
+                    'The SendGrid API request timed out') from e
+            raise
 
     def set_sendgrid_data_residency(self, region):
         """
@@ -78,6 +94,7 @@ class BaseInterface(object):
                 self.client = python_http_client.Client(
                     host=self.host,
                     request_headers=self._default_headers,
-                    version=3)
+                    version=3,
+                    timeout=self.timeout)
         else:
             raise ValueError("region can only be \"eu\" or \"global\"")

--- a/sendgrid/helpers/mail/exceptions.py
+++ b/sendgrid/helpers/mail/exceptions.py
@@ -8,6 +8,11 @@ class SendGridException(Exception):
     pass
 
 
+class SendGridTimeoutError(SendGridException):
+    """Exception raised when an HTTP request to the SendGrid API times out"""
+    pass
+
+
 class ApiKeyIncludedException(SendGridException):
     """Exception raised for when Twilio SendGrid API Key included in message text"""
 

--- a/sendgrid/sendgrid.py
+++ b/sendgrid/sendgrid.py
@@ -33,7 +33,8 @@ class SendGridAPIClient(BaseInterface):
             self,
             api_key=None,
             host='https://api.sendgrid.com',
-            impersonate_subuser=None):
+            impersonate_subuser=None,
+            timeout=30):
         """
         Construct the Twilio SendGrid v3 API object.
         Note that the underlying client is being set up during initialization,
@@ -51,8 +52,11 @@ class SendGridAPIClient(BaseInterface):
         :type impersonate_subuser: string
         :param host: base URL for API calls
         :type host: string
+        :param timeout: the timeout (in seconds) for HTTP requests.
+                        Defaults to 30. Set to None to disable.
+        :type timeout: int
         """
         self.api_key = api_key or os.environ.get('SENDGRID_API_KEY')
         auth = 'Bearer {}'.format(self.api_key)
 
-        super(SendGridAPIClient, self).__init__(auth, host, impersonate_subuser)
+        super(SendGridAPIClient, self).__init__(auth, host, impersonate_subuser, timeout=timeout)

--- a/sendgrid/twilio_email.py
+++ b/sendgrid/twilio_email.py
@@ -35,7 +35,8 @@ class TwilioEmailAPIClient(BaseInterface):
             username=None,
             password=None,
             host='https://email.twilio.com',
-            impersonate_subuser=None):
+            impersonate_subuser=None,
+            timeout=30):
         """
         Construct the Twilio Email v3 API object.
         Note that the underlying client is being set up during initialization,
@@ -59,6 +60,9 @@ class TwilioEmailAPIClient(BaseInterface):
         :type impersonate_subuser: string
         :param host: base URL for API calls
         :type host: string
+        :param timeout: the timeout (in seconds) for HTTP requests.
+                        Defaults to 30. Set to None to disable.
+        :type timeout: int
         """
         self.username = username or \
                         os.environ.get('TWILIO_API_KEY') or \
@@ -70,4 +74,4 @@ class TwilioEmailAPIClient(BaseInterface):
 
         auth = 'Basic ' + b64encode('{}:{}'.format(self.username, self.password).encode()).decode()
 
-        super(TwilioEmailAPIClient, self).__init__(auth, host, impersonate_subuser)
+        super(TwilioEmailAPIClient, self).__init__(auth, host, impersonate_subuser, timeout=timeout)

--- a/test/unit/test_sendgrid.py
+++ b/test/unit/test_sendgrid.py
@@ -1,5 +1,10 @@
+import socket
 import unittest
+from unittest.mock import patch
+import urllib.error
+
 import sendgrid
+from sendgrid.helpers.mail.exceptions import SendGridTimeoutError
 
 class UnitTests(unittest.TestCase):
     def test_host_with_no_region(self):
@@ -25,3 +30,21 @@ class UnitTests(unittest.TestCase):
         sg = sendgrid.SendGridAPIClient(api_key='MY_API_KEY')
         with self.assertRaises(ValueError):
             sg.set_sendgrid_data_residency("abc")
+
+    def test_timeout_default(self):
+        sg = sendgrid.SendGridAPIClient(api_key='MY_API_KEY')
+        self.assertEqual(sg.timeout, 30)
+        self.assertEqual(sg.client.timeout, 30)
+
+    def test_timeout_set_via_constructor(self):
+        sg = sendgrid.SendGridAPIClient(api_key='MY_API_KEY', timeout=10)
+        self.assertEqual(sg.timeout, 10)
+        self.assertEqual(sg.client.timeout, 10)
+
+    @patch('python_http_client.Client')
+    def test_send_timeout_raises_sendgrid_timeout_error(self, MockClient):
+        sg = sendgrid.SendGridAPIClient(api_key='MY_API_KEY')
+        sg.client.mail.send.post.side_effect = urllib.error.URLError(
+            reason=socket.timeout('timed out'))
+        with self.assertRaises(SendGridTimeoutError):
+            sg.send({'key': 'value'})

--- a/test/unit/test_twilio_email.py
+++ b/test/unit/test_twilio_email.py
@@ -35,3 +35,13 @@ class UnitTests(unittest.TestCase):
         self.assertEqual(mail_client.username, 'username')
         self.assertEqual(mail_client.password, 'password')
         self.assertEqual(mail_client.auth, 'Basic dXNlcm5hbWU6cGFzc3dvcmQ=')
+
+    def test_timeout_default(self):
+        mail_client = TwilioEmailAPIClient('username', 'password')
+        self.assertEqual(mail_client.timeout, 30)
+        self.assertEqual(mail_client.client.timeout, 30)
+
+    def test_timeout_set_via_constructor(self):
+        mail_client = TwilioEmailAPIClient('username', 'password', timeout=10)
+        self.assertEqual(mail_client.timeout, 10)
+        self.assertEqual(mail_client.client.timeout, 10)


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test, misc.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

HTTP requests made by this library (e.g., to send emails via the APIs) have no timeout by default. If a network issue causes a request to hang, the calling process blocks indefinitely. 

This PR adds a timeout parameter (defaulting to 30 seconds) to `SendGridAPIClient` and `TwilioEmailAPIClient`. The underlying `python_http_client` already supports this. Callers can override the default or disable it by passing `timeout=None`.

Technically, this is a breaking change. Code that previously hung silently will now raise the new `SendGridTimeoutError` exception after `timeout` seconds. Anyone relying on infinite wait (intentionally or not) will see new exceptions.

That said, it's hard to argue the previous behavior was correct. A process hanging forever isn't really "working." But  strictly by semver rules, changing the default from no timeout to 30 seconds is a breaking change since it alters existing behavior.

### Checklist

- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have read the [Contribution Guidelines](https://github.com/sendgrid/sendgrid-python/blob/main/CONTRIBUTING.md)
  and my PR follows them
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, please file a [support ticket](https://support.sendgrid.com).